### PR TITLE
Fetch Vault from upstream when building Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ cargo build
 ```
 
 ## How to update the web-vault used
+If you're using docker image, you can just update `VAULT_VERSION` variable in Dockerfile and rebuild the image.
+
 Install `node.js` and either `yarn` or `npm` (usually included with node)
 
 Clone the web-vault outside the project:

--- a/web-vault/settings.Production.json
+++ b/web-vault/settings.Production.json
@@ -1,0 +1,9 @@
+{
+    "appSettings": {
+        "apiUri": "/api",
+        "identityUri": "/identity",
+        "iconsUri": "/icons",
+        "stripeKey": "",
+        "braintreeKey": ""
+    }
+}


### PR DESCRIPTION
Hi, this extends the Dockerfile and builds the Vault files straight from upstream, so you can switch it easily. Should make it easier to follow the upstream.