### PR TITLE
Add support for adding and viewing of org ciphers

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -27,6 +27,7 @@ pub fn routes() -> Vec<Route> {
         get_ciphers,
         get_cipher,
         post_ciphers,
+        post_ciphers_admin,
         post_ciphers_import,
         post_attachment,
         delete_attachment_post,

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -229,12 +229,12 @@ struct OrgIdData {
 
 #[get("/ciphers/organization-details?<data>")]
 fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> JsonResult {
-
-    // Get list of ciphers in org?
+    let ciphers = Cipher::find_by_org(&data.organizationId, &conn);
+    let ciphers_json: Vec<Value> = ciphers.iter().map(|c| c.to_json(&headers.host, &conn)).collect();
 
     Ok(Json(json!({
-        "Data": [],
-        "Object": "list"
+      "Data": ciphers_json,
+      "Object": "list",
     })))
 }
 

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -96,7 +96,7 @@ impl Cipher {
             "RevisionDate": format_date(&self.updated_at),
             "FolderId": self.folder_uuid,
             "Favorite": self.favorite,
-            "OrganizationId": "",
+            "OrganizationId": self.organization_uuid,
             "Attachments": attachments_json,
             "OrganizationUseTotp": false,
 
@@ -151,6 +151,12 @@ impl Cipher {
     pub fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         ciphers::table
             .filter(ciphers::user_uuid.eq(user_uuid))
+            .load::<Self>(&**conn).expect("Error loading ciphers")
+    }
+
+    pub fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+        ciphers::table
+            .filter(ciphers::organization_uuid.eq(org_uuid))
             .load::<Self>(&**conn).expect("Error loading ciphers")
     }
 


### PR DESCRIPTION
This extends the API to post cipher for an Organization. Also `Cipher::to_json()` now also returns organization uuid if present.