### PR TITLE
Also list shared ciphers in find_by_user

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -168,7 +168,7 @@ fn delete_account(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> E
     }
 
     // Delete ciphers and their attachments
-    for cipher in Cipher::find_by_user(&user.uuid, &conn) {
+    for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
         for a in Attachment::find_by_cipher(&cipher.uuid, &conn) { a.delete(&conn); }
 
         cipher.delete(&conn);

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -503,7 +503,7 @@ fn delete_all(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> Empty
     }
 
     // Delete ciphers and their attachments
-    for cipher in Cipher::find_by_user(&user.uuid, &conn) {
+    for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
         _delete_cipher(cipher, &conn);
     }
 

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -243,6 +243,7 @@ impl Cipher {
             )
         ))
         .select(ciphers::all_columns)
+        .distinct()
         .load::<Self>(&**conn).expect("Error loading ciphers")
     }
 


### PR DESCRIPTION
This splits the `find_by_user` into two separate functions: `find_owned_by_user` which retains previous functionality and lists only ciphers directly owned by user and `find_by_user` which now also lists all ciphers shared with user.

As a result shared ciphers are now visible in user's vault.

There's also small change in the `/api/ciphers/purge` handler to use the `find_owned_by_user` instead to only purge user's content and not the shared stuff.