### PR TITLE
set max storage to non-null value

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -154,7 +154,7 @@ impl UserOrganization {
             "UseGroups": false,
             "UseTotp": false,
 
-            "MaxStorageGb": null,
+            "MaxStorageGb": 999999999,
 
             // These are per user
             "Key": self.key,


### PR DESCRIPTION
This should enable adding attachments to shared ciphers and resolve #15.