### PR TITLE
Remove user_uuid when sharing to organization

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -128,6 +128,7 @@ fn update_cipher_from_data(cipher: &mut Cipher, data: CipherData, headers: &Head
                 None => err!("You don't have permission to add item to organization"),
                 Some(org_user) => if org_user.has_full_access() {
                     cipher.organization_uuid = Some(org_id);
+                    cipher.user_uuid = None;
                 } else {
                     err!("You don't have permission to add cipher directly to organization")
                 }


### PR DESCRIPTION
This fixes a but for sharing Ciphers where `user_uuid` was left in the cipher record which prevented other users from accessing the cipher even if they should be able to. 