### PR TITLE
Remove dependent items when removing cipher

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -169,9 +169,10 @@ fn delete_account(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> E
 
     // Delete ciphers and their attachments
     for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
-        for a in Attachment::find_by_cipher(&cipher.uuid, &conn) { a.delete(&conn); }
-
-        cipher.delete(&conn);
+        match cipher.delete(&conn) {
+            Ok(()) => (),
+            Err(_) => err!("Failed deleting cipher")
+        }
     }
 
     // Delete folders

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -450,9 +450,10 @@ fn delete_attachment(uuid: String, attachment_id: String, headers: Headers, conn
     }
 
     // Delete attachment
-    attachment.delete(&conn);
-
-    Ok(())
+    match attachment.delete(&conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Deleting attachement failed")
+    }
 }
 
 #[post("/ciphers/<uuid>/delete")]
@@ -549,7 +550,10 @@ fn delete_all(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> Empty
 
     // Delete ciphers and their attachments
     for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
-        _delete_cipher(cipher, &conn);
+        match cipher.delete(&conn) {
+            Ok(()) => (),
+            Err(_) => err!("Failed deleting cipher")
+        }
     }
 
     // Delete folders
@@ -568,15 +572,8 @@ fn _delete_cipher_by_uuid(uuid: &str, headers: &Headers, conn: &DbConn) -> Empty
         err!("Cipher can't be deleted by user")
     }
 
-    _delete_cipher(cipher, conn);
-
-    Ok(())
-}
-
-fn _delete_cipher(cipher: Cipher, conn: &DbConn) {
-    // Delete the attachments
-    for a in Attachment::find_by_cipher(&cipher.uuid, &conn) { a.delete(&conn); }
-
-    // Delete the cipher
-    cipher.delete(conn);
+    match cipher.delete(conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Failed deleting cipher")
+    }
 }

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -204,4 +204,10 @@ impl CollectionCipher {
             _ => false,
         }
     }
+
+    pub fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        diesel::delete(ciphers_collections::table
+            .filter(ciphers_collections::cipher_uuid.eq(cipher_uuid))
+        ).execute(&**conn).and(Ok(()))
+    }
 }

--- a/src/db/models/folder.rs
+++ b/src/db/models/folder.rs
@@ -117,6 +117,12 @@ impl FolderCipher {
         ).execute(&**conn).and(Ok(()))
     }
 
+    pub fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        diesel::delete(folders_ciphers::table
+            .filter(folders_ciphers::cipher_uuid.eq(cipher_uuid))
+        ).execute(&**conn).and(Ok(()))
+    }
+
     pub fn find_by_folder_and_cipher(folder_uuid: &str, cipher_uuid: &str, conn: &DbConn) -> Option<Self> {
         folders_ciphers::table
             .filter(folders_ciphers::folder_uuid.eq(folder_uuid))


### PR DESCRIPTION
This makes sure, that we delete all dependent records (`Attachment`, `FolderCipher`, `CollectionCipher`) before deleting Cipher itself. Otherwise the deleting will fail. 

This also implements better error handling (#6) for `delete` and moves some functionality out of request handling under `cipher.rs`.