### PR TITLE
Improve Folder::delete() to handle FolderCipher

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -176,7 +176,12 @@ fn delete_account(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> E
     }
 
     // Delete folders
-    for f in Folder::find_by_user(&user.uuid, &conn) { f.delete(&conn); }
+    for f in Folder::find_by_user(&user.uuid, &conn) {
+        match f.delete(&conn) {
+            Ok(()) => (),
+            Err(_) => err!("Failed deleting folder")
+        } 
+    }
 
     // Delete devices
     for d in Device::find_by_user(&user.uuid, &conn) { d.delete(&conn); }

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -557,7 +557,12 @@ fn delete_all(data: Json<PasswordData>, headers: Headers, conn: DbConn) -> Empty
     }
 
     // Delete folders
-    for f in Folder::find_by_user(&user.uuid, &conn) { f.delete(&conn); }
+    for f in Folder::find_by_user(&user.uuid, &conn) {
+        match f.delete(&conn) {
+            Ok(()) => (),
+            Err(_) => err!("Failed deleting folder")
+        } 
+    }
 
     Ok(())
 }

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -89,11 +89,9 @@ fn delete_folder(uuid: String, headers: Headers, conn: DbConn) -> EmptyResult {
         err!("Folder belongs to another user")
     }
 
-    // Delete FolderCipher mappings
-    for fc in FolderCipher::find_by_folder(&uuid, &conn) { fc.delete(&conn).expect("Error deleting mapping"); }
-
     // Delete the actual folder entry
-    folder.delete(&conn);
-
-    Ok(())
+    match folder.delete(&conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Failed deleting folder")
+    }
 }

--- a/src/db/models/folder.rs
+++ b/src/db/models/folder.rs
@@ -81,13 +81,14 @@ impl Folder {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> bool {
-        match diesel::delete(folders::table.filter(
-            folders::uuid.eq(self.uuid)))
-            .execute(&**conn) {
-            Ok(1) => true, // One row deleted
-            _ => false,
-        }
+    pub fn delete(self, conn: &DbConn) -> QueryResult<()> {
+        FolderCipher::delete_all_by_folder(&self.uuid, &conn)?;
+
+        diesel::delete(
+            folders::table.filter(
+                folders::uuid.eq(self.uuid)
+            )
+        ).execute(&**conn).and(Ok(()))
     }
 
     pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
@@ -120,6 +121,12 @@ impl FolderCipher {
     pub fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> QueryResult<()> {
         diesel::delete(folders_ciphers::table
             .filter(folders_ciphers::cipher_uuid.eq(cipher_uuid))
+        ).execute(&**conn).and(Ok(()))
+    }
+
+    pub fn delete_all_by_folder(folder_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        diesel::delete(folders_ciphers::table
+            .filter(folders_ciphers::folder_uuid.eq(folder_uuid))
         ).execute(&**conn).and(Ok(()))
     }
 


### PR DESCRIPTION
This moves the `FolderCipher` deletion into `Folder.delete()` so we do also remove the `FolderCipher` mapping no matter where we call the `delete()`. Also improvements were added to handle failures better as per #6. 