### PR TITLE
Fix reference in attachments table

### DIFF
--- a/migrations/2018-05-25-232323_update_attachments_reference/up.sql
+++ b/migrations/2018-05-25-232323_update_attachments_reference/up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE attachments RENAME TO oldAttachments;
+
+CREATE TABLE attachments (
+  id          TEXT    NOT NULL PRIMARY KEY,
+  cipher_uuid TEXT    NOT NULL REFERENCES ciphers (uuid),
+  file_name   TEXT    NOT NULL,
+  file_size   INTEGER NOT NULL
+
+);
+
+INSERT INTO attachments (id, cipher_uuid, file_name, file_size) 
+SELECT id, cipher_uuid, file_name, file_size FROM oldAttachments;
+
+DROP TABLE oldAttachments;


### PR DESCRIPTION
We broke the attachment functionality in 514a372 when we didn't update the table reference for attachment and it still points to old, deleted cipher table. This migrates the attachment records into new table with proper reference.