### PR TITLE
Better check for cipher access

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -3,7 +3,7 @@ use serde_json::Value as JsonValue;
 
 use uuid::Uuid;
 
-use super::{User, Organization, UserOrganization, Attachment, FolderCipher, CollectionCipher, UserOrgType};
+use super::{User, Organization, Attachment, FolderCipher, CollectionCipher, UserOrgType};
 
 #[derive(Debug, Identifiable, Queryable, Insertable, Associations)]
 #[table_name = "ciphers"]


### PR DESCRIPTION
This checks out two TODOs: 
1. Extends `Cipher::is_write_accessible_to_user` with a check for any collection that might give R/W access to cipher.
2. Implements `Cipher::is_accessible_to_user` with a proper check for any RO access. 

The current solution works quite well, but I don't like the code repetition. Any input would be greatly appreciated how to solve this in some reasonable manner. I was thinking about using `into_boxed()` at some stage to promote some code reuse, but I just don't know enough about diesel to pull this off successfully.

Other approach would be to split it into multiple sub-checks and aggregate those but that would lead to 5x the amount of queries, which I'd like to avoid.

Any ideas?