### PR TITLE
Add limits configuration to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ You could also set the `SIGNUPS_ALLOWED` environment variable. To do that when u
 -e SIGNUPS_ALLOWED=false
 ```
 
+## Changing the API request size limit
+
+By default the API calls are limited to 10MB. This should be sufficient for most cases, however if you want to support large imports, this might be limiting you. On the other hand you might want to limit the request size to something smaller than that to prevent API abuse and possible DOS attack, especially if running with limited resources.
+
+To set the limit, you can use the `ROCKET_LIMITS` variable. Example here shows 10MB limit for posted json in the body (this is the default):
+```
+-e ROCKET_LIMITS={json=10485760}
+```
+
 ## Enabling HTTPS
 To enable HTTPS, you need to configure the `ROCKET_TLS` option, the same way as `SIGNUPS_ALLOWED`.
 


### PR DESCRIPTION
Now that we know it works this way, we should probably document it. :writing_hand: 