### PR TITLE
Add a link to Archlinux AUR packages

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,6 @@
 ## Manual Setup (Advanced)
+_( bitwarden_rs is already packaged for Archlinux: There is an AUR package [with](https://aur.archlinux.org/packages/bitwarden_rs-vault-git/) and 
+[without](https://aur.archlinux.org/packages/bitwarden_rs-git/) the vault web interface available.)_
 ### Dependencies
 - `Rust nightly` (strongly recommended to use [rustup](https://rustup.rs/))
 - `OpenSSL` (should be available in path, install through your system's package manager or use the [prebuilt binaries](https://wiki.openssl.org/index.php/Binaries))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ This is Bitwarden server API implementation written in rust compatible with [ups
 
 Image is based on [Rust implementation of Bitwarden API](https://github.com/dani-garcia/bitwarden_rs).
 
+It is also packaged for Archlinux: There is an AUR package [with](https://aur.archlinux.org/packages/bitwarden_rs-vault-git/) and 
+[without](https://aur.archlinux.org/packages/bitwarden_rs-git/) the vault web interface.
+
 _*Note, that this project is not associated with the [Bitwarden](https://bitwarden.com/) project nor 8bit Solutions LLC._
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@ This is Bitwarden server API implementation written in rust compatible with [ups
 
 Image is based on [Rust implementation of Bitwarden API](https://github.com/dani-garcia/bitwarden_rs).
 
-It is also packaged for Archlinux: There is an AUR package [with](https://aur.archlinux.org/packages/bitwarden_rs-vault-git/) and 
-[without](https://aur.archlinux.org/packages/bitwarden_rs-git/) the vault web interface.
-
 _*Note, that this project is not associated with the [Bitwarden](https://bitwarden.com/) project nor 8bit Solutions LLC._
 
 ## Features
@@ -198,7 +195,6 @@ docker build -t bitwarden_rs .
 ## Building binary
 
 For building binary outside the Docker environment and running it locally without docker, please see [build instructions](BUILD.md).
-
 
 ## Backing up your vault
 


### PR DESCRIPTION
Hi!
I made two packages for Archlinux, one for the purists (without web interface) and one with the web interface and wanted to link to them here.
I'm not sure if that is the best position to advertise this, let me know if you think the links are better put elsewhere.

Apart from that: If you have any other suggestions/remarks for repackaging, please tell me. 

Currently I'm linking to the latest master commit, but I would really welcome it if you could make a release every now and then.
Thanks for your great work!