### PR TITLE
Do not show organization stuff to not accepted user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Image is based on [Rust implementation of Bitwarden API](https://github.com/dani
 
 _*Note, that this project is not associated with the [Bitwarden](https://bitwarden.com/) project nor 8bit Solutions LLC._
 
-## Table of contents <!-- omit in toc -->
+**Table of contents**
+
 - [Features](#features)
+- [Missing features](#missing-features)
 - [Docker image usage](#docker-image-usage)
   - [Starting a container](#starting-a-container)
   - [Updating the bitwarden image](#updating-the-bitwarden-image)

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -268,6 +268,7 @@ impl UserOrganization {
     pub fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         users_organizations::table
             .filter(users_organizations::user_uuid.eq(user_uuid))
+            .filter(users_organizations::status.eq(UserOrgStatus::Confirmed as i32))
             .load::<Self>(&**conn).unwrap_or(vec![])
     }
 


### PR DESCRIPTION
This should hide collections and organizations from user that has not been yet accepted. 

(and I've sneaked in some readme update to avoid issue with visible comment on docker hub)