### PR TITLE
Reflect changes in Archlinux packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ For building binary outside the Docker environment and running it locally withou
 
 ### Arch Linux
 
-Bitwarden_rs is already packaged for Archlinux thanks to @mqus. There is an AUR package [with](https://aur.archlinux.org/packages/bitwarden_rs-vault-git/) and 
-[without](https://aur.archlinux.org/packages/bitwarden_rs-git/) the vault web interface available.
+Bitwarden_rs is already packaged for Archlinux thanks to @mqus. There is an [AUR package](https://aur.archlinux.org/packages/bitwarden_rs) (optionally with the [vault web interface](https://aur.archlinux.org/packages/bitwarden_rs-vault/) ) available.
 
 ## Backing up your vault
 


### PR DESCRIPTION
I changed the way bitwarden_rs is packaged (the web interface is now an addon-package instead of bundled) and added a 'stable' package which follows recent releases.
 I assume that following releases instead of the master branch is encouraged so I removed the link to the (still existing) bitwarden_rs-git package which does the latter.

OT-Comment on the diff: huh? I edited the file in the github-editor but somehow that last line got a change I didn't intent to make and I can't seem to find a difference... strange