### PR TITLE
Change number of workers in image, document the setting (fixes #90)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN cargo build --release
 FROM debian:stretch-slim
 
 ENV ROCKET_ENV "staging"
+ENV ROCKET_WORKERS=10
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y\

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ _*Note, that this project is not associated with the [Bitwarden](https://bitward
     - [attachments location](#attachments-location)
     - [icons cache](#icons-cache)
   - [Changing the API request size limit](#changing-the-api-request-size-limit)
+  - [Changing the number of workers](#changing-the-number-of-workers)
   - [Other configuration](#other-configuration)
 - [Building your own image](#building-your-own-image)
 - [Building binary](#building-binary)
@@ -228,6 +229,20 @@ To set the limit, you can use the `ROCKET_LIMITS` variable. Example here shows 1
 ```sh
 docker run -d --name bitwarden \
   -e ROCKET_LIMITS={json=10485760} \
+  -v /bw-data/:/data/ \
+  -p 80:80 \
+  mprasil/bitwarden:latest
+```
+
+### Changing the number of workers
+
+When you run bitwarden_rs, it spawns `2 * <number of cpu cores>` workers to handle requests. On some systems this might lead to low number of workers and hence slow performance, so the default in the docker image is changed to spawn 10 threads. You can override this setting to increase or decrease the number of workers by setting the `ROCKET_WORKERS` variable.
+
+In the example bellow, we're starting with 20 workers:
+
+```sh
+docker run -d --name bitwarden \
+  -e ROCKET_WORKERS=20 \
   -v /bw-data/:/data/ \
   -p 80:80 \
   mprasil/bitwarden:latest


### PR DESCRIPTION
This is setting the number of workers to 10. The issue with the default behavior was that on some systems with low number of cores this leads to very low number of workers (`2 * $cpu_cores_number`) and poor performance. Especially on cloud instances, that often have just one core.

The default is set somewhat conservatively to 10 as most browsers won't create more than ~8 simultaneous connections to the same domain anyway. The documentation was added to let users know, they can increase this number in case they have large number of users where 10 workers might not be enough.