### PR TITLE
Return 404 in case the path doesn't match instead of 500

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitwarden_rs"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>"]
 
 [dependencies]


### PR DESCRIPTION
Currently we return 404 if `WEB_VAULT_ENABLED` is set to `false` and 500 if Vault is enabled. Upstream API responds with 404 for non-existent endpoints, so we should do the same.