### PR TITLE
Implementing PUT for 'api/ciphers/move' (#99)

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -483,8 +483,9 @@ fn delete_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbCon
     Ok(())
 }
 
-#[post("/ciphers/move", data = "<data>")]
+#[put("/ciphers/move", data = "<data>")]
 fn move_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbConn) -> EmptyResult {
+    println!("{}", "inside put");
     let data = data.into_inner().data;
 
     let folder_id = match data.get("FolderId") {

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -485,7 +485,6 @@ fn delete_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbCon
 
 #[put("/ciphers/move", data = "<data>")]
 fn move_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbConn) -> EmptyResult {
-    println!("{}", "inside put");
     let data = data.into_inner().data;
 
     let folder_id = match data.get("FolderId") {

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -483,8 +483,60 @@ fn delete_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbCon
     Ok(())
 }
 
-#[put("/ciphers/move", data = "<data>")]
+#[post("/ciphers/move", data = "<data>")]
 fn move_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbConn) -> EmptyResult {
+    let data = data.into_inner().data;
+
+    let folder_id = match data.get("FolderId") {
+        Some(folder_id) => {
+            match folder_id.as_str() {
+                Some(folder_id) => {
+                    match Folder::find_by_uuid(folder_id, &conn) {
+                        Some(folder) => {
+                            if folder.user_uuid != headers.user.uuid {
+                                err!("Folder is not owned by user")
+                            }
+                            Some(folder.uuid)
+                        }
+                        None => err!("Folder doesn't exist")
+                    }
+                }
+                None => err!("Folder id provided in wrong format")
+            }
+        }
+        None => None
+    };
+
+    let uuids = match data.get("Ids") {
+        Some(ids) => match ids.as_array() {
+            Some(ids) => ids.iter().filter_map(|uuid| { uuid.as_str() }),
+            None => err!("Posted ids field is not an array")
+        },
+        None => err!("Request missing ids field")
+    };
+
+    for uuid in uuids {
+        let mut cipher = match Cipher::find_by_uuid(uuid, &conn) {
+            Some(cipher) => cipher,
+            None => err!("Cipher doesn't exist")
+        };
+
+        if !cipher.is_accessible_to_user(&headers.user.uuid, &conn) {
+            err!("Cipher is not accessible by user")
+        }
+
+        // Move cipher
+        if cipher.move_to_folder(folder_id.clone(), &headers.user.uuid, &conn).is_err() {
+            err!("Error saving the folder information")
+        }
+        cipher.save(&conn);
+    }
+
+    Ok(())
+}
+
+#[put("/ciphers/move", data = "<data>")]
+fn move_cipher_selected_put(data: JsonUpcase<Value>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data = data.into_inner().data;
 
     let folder_id = match data.get("FolderId") {

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -46,6 +46,7 @@ pub fn routes() -> Vec<Route> {
         delete_cipher_selected,
         delete_all,
         move_cipher_selected,
+        move_cipher_selected_put,
 
         get_folders,
         get_folder,


### PR DESCRIPTION
Have made changes to support `PUT` call for `/api/ciphers/move` instead of `POST` as  new vault version (2.0) makes a `PUT` call.