### PR TITLE
Implemented PUT for single cipher sharing (#97)

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -365,6 +365,11 @@ fn post_cipher_share(uuid: String, data: JsonUpcase<ShareCipherData>, headers: H
     }
 }
 
+#[put("/ciphers/<uuid>/share", data = "<data>")]
+fn put_cipher_share(uuid: String, data: JsonUpcase<ShareCipherData>, headers: Headers, conn: DbConn) -> JsonResult {
+    post_cipher_share(uuid, data, headers, conn)
+}
+
 #[post("/ciphers/<uuid>/attachment", format = "multipart/form-data", data = "<data>")]
 fn post_attachment(uuid: String, data: Data, content_type: &ContentType, headers: Headers, conn: DbConn) -> JsonResult {
     let cipher = match Cipher::find_by_uuid(&uuid, &conn) {

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -41,6 +41,7 @@ pub fn routes() -> Vec<Route> {
         delete_attachment,
         post_cipher_admin,
         post_cipher_share,
+        put_cipher_share,
         post_cipher,
         put_cipher,
         delete_cipher_post,


### PR DESCRIPTION
Implemented PUT for "api//ciphers/<uuid>/share" as the new Vault version (2.0) is no longer using POST.