### PR TITLE
Changes to change email without email verification code (#110)

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -163,8 +163,9 @@ struct EmailTokenData {
 #[post("/accounts/email-token", data = "<data>")]
 fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: EmailTokenData = data.into_inner().data;
+    let mut user = headers.user;
 
-    if !headers.user.check_valid_password(&data.MasterPasswordHash) {
+    if !user.check_valid_password(&data.MasterPasswordHash) {
         err!("Invalid password")
     }
 
@@ -172,6 +173,10 @@ fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: Db
         err!("Email already in use");
     }
 
+    user.email = data.NewEmail;
+
+    user.save(&conn);
+    
     Ok(())
 }
 


### PR DESCRIPTION
Changes to change email address on click of "Continue" on "My Accounts" screen under "Change Email", without the need of email verification code.