### PR TITLE
Implement update_revision trigger

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -242,7 +242,11 @@ fn post_ciphers_import(data: JsonUpcase<ImportData>, headers: Headers, conn: DbC
         cipher.move_to_folder(folder_uuid, &headers.user.uuid.clone(), &conn).ok();
     }
 
-    Ok(())
+    let mut user = headers.user;
+    match user.update_revision(&conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Failed to update the revision, please log out and log back in to finish import.")
+    }
 }
 
 #[post("/ciphers/<uuid>/admin", data = "<data>")]

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -154,6 +154,16 @@ impl User {
         }
     }
 
+    pub fn update_revision(&mut self, conn: &DbConn) -> QueryResult<()> {
+        diesel::update(
+            users::table.filter(
+                users::uuid.eq(&self.uuid)
+            )
+        )
+        .set(users::updated_at.eq(Utc::now().naive_utc()))
+        .execute(&**conn).and(Ok(()))
+    }
+
     pub fn find_by_mail(mail: &str, conn: &DbConn) -> Option<Self> {
         let lower_mail = mail.to_lowercase();
         users::table


### PR DESCRIPTION
This adds `update_revision` for `user`. So far it only seems to be necessary for the cipher import handling, so I've used it there. This should resolve #117, hopefully the last outstanding Vault 2 related issue.