### PR TITLE
Add PUT alias for editing cipher

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -251,9 +251,14 @@ fn post_ciphers_import(data: JsonUpcase<ImportData>, headers: Headers, conn: DbC
     }
 }
 
+
+#[put("/ciphers/<uuid>/admin", data = "<data>")]
+fn put_cipher_admin(uuid: String, data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn) -> JsonResult {
+    put_cipher(uuid, data, headers, conn)
+}
+
 #[post("/ciphers/<uuid>/admin", data = "<data>")]
 fn post_cipher_admin(uuid: String, data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn) -> JsonResult {
-    // TODO: Implement this correctly
     post_cipher(uuid, data, headers, conn)
 }
 

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -32,6 +32,7 @@ pub fn routes() -> Vec<Route> {
         get_cipher_admin,
         get_cipher_details,
         post_ciphers,
+        put_cipher_admin,
         post_ciphers_admin,
         post_ciphers_import,
         post_attachment,


### PR DESCRIPTION
This should fix the issue with editing cipher in the Vault. I've also removed the TODO as I believe we actually did implement this correctly when we re-did the `Cipher::is_write_accessible_to_user`.