### PR TITLE
Actually update the revision date for user struct, not just in DB

### DIFF
--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -155,12 +155,13 @@ impl User {
     }
 
     pub fn update_revision(&mut self, conn: &DbConn) -> QueryResult<()> {
+        self.updated_at = Utc::now().naive_utc();
         diesel::update(
             users::table.filter(
                 users::uuid.eq(&self.uuid)
             )
         )
-        .set(users::updated_at.eq(Utc::now().naive_utc()))
+        .set(users::updated_at.eq(&self.updated_at))
         .execute(&**conn).and(Ok(()))
     }
 


### PR DESCRIPTION
The function borrows the user struct mutably, but doesn't actually update the revision date there. In our current use case this wasn't a problem, but might be an issue later on. 