### PR TITLE
Update affected users revision when there are collection changes

### DIFF
--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -154,6 +154,14 @@ impl User {
         }
     }
 
+    pub fn update_uuid_revision(uuid: &str, conn: &DbConn) {
+        if let Some(mut user) = User::find_by_uuid(&uuid, conn) {
+            if user.update_revision(conn).is_err(){
+                println!("Warning: Failed to update revision for {}", user.email);
+            };
+        };
+    }
+
     pub fn update_revision(&mut self, conn: &DbConn) -> QueryResult<()> {
         diesel::update(
             users::table.filter(


### PR DESCRIPTION
It appears, that Vault 2 checks the revision to know whether it should update the cipher data. This change updates user's revision when major changes like collection access change occurs. This way the user can see proper ciphers as he gained/lost access to them without logging off and back in.