### PR TITLE
Update affected users revision on cipher and folder change

### DIFF
--- a/src/db/models/folder.rs
+++ b/src/db/models/folder.rs
@@ -71,6 +71,7 @@ use db::schema::{folders, folders_ciphers};
 /// Database methods
 impl Folder {
     pub fn save(&mut self, conn: &DbConn) -> bool {
+        User::update_uuid_revision(&self.user_uuid, conn);
         self.updated_at = Utc::now().naive_utc();
 
         match diesel::replace_into(folders::table)
@@ -82,6 +83,7 @@ impl Folder {
     }
 
     pub fn delete(self, conn: &DbConn) -> QueryResult<()> {
+        User::update_uuid_revision(&self.user_uuid, conn);
         FolderCipher::delete_all_by_folder(&self.uuid, &conn)?;
 
         diesel::delete(


### PR DESCRIPTION
This should update revision for all affected users on cipher and folder changes. The `find_by_cipher_and_org` definitely needs another pair of eyes to double-check. (from my limited testing it does what it should)