### PR TITLE
Bump version to 0.13.0 - latest Vault v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitwarden_rs"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>"]
 
 [dependencies]


### PR DESCRIPTION
Can you also do a release? This is in preparation for next PR merging in beta. 