### PR TITLE
Update BUILD.md for web-vault 2.x.x

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -17,28 +17,22 @@ cargo build --release
 When run, the server is accessible in [http://localhost:80](http://localhost:80).
 
 ### Install the web-vault
-Download the latest official release from the [releases page](https://github.com/bitwarden/web/releases) and extract it.
-
-Modify `web-vault/settings.Production.json` to look like this:
-```json
-{
-  "appSettings": {
-    "apiUri": "/api",
-    "identityUri": "/identity",
-    "iconsUri": "/icons",
-    "stripeKey": "",
-    "braintreeKey": ""
-  }
-}
+Clone the git repository at [bitwarden/web](https://github.com/bitwarden/web) and checkout the latest release tag (e.g. v2.1.1):
+```sh
+# clone the repository
+git clone https://github.com/bitwarden/web.git web-vault
+cd web-vault
+# switch to the latest tag
+git checkout "$(git tag | tail -n1)"
 ```
 
 Then, run the following from the `web-vault` directory:
 ```sh
 npm install
-npx gulp dist:selfHosted
+npm run dist:selfhost
 ```
 
-Finally copy the contents of the `web-vault/dist` folder into the `bitwarden_rs/web-vault` folder.
+Finally copy the contents of the `web-vault/build` folder into the `bitwarden_rs/web-vault` folder.
 
 # Configuration
 The available configuration options are documented in the default `.env` file, and they can be modified by uncommenting the desired options in that file or by setting their respective environment variables. Look at the README file for the main configuration options available.


### PR DESCRIPTION
Update BUILD.md to reflect changes to the web-vault build process

I switched to `git clone` instead of unpacking release archives because there is a git submodule (jslib) which is not packed into the archives. One could also download the specific commit archive of [bitwarden/jslib](https://github.com/bitwarden/jslib) for the release archive and unpack it into the `jslib` directory, but this would be a much more complex process, because we would also have to explain how to find the matching commit hash.

I also removed the instructions to change upstream files because `npm run dist:selfhost` already applies everything changed by the docker patch, if I'm not mistaken(See [bitwarden/web/package.json](https://github.com/bitwarden/web/blob/master/package.json#L15) for setting the env variables and [services.modules.ts](https://github.com/bitwarden/web/blob/master/src/app/services/services.module.ts#L127) which uses it).