### PR TITLE
Fix editing users in Organization

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -476,8 +476,8 @@ fn edit_user(org_id: String, org_user_id: String, data: JsonUpcase<EditUserData>
     };
 
     if new_type != user_to_edit.type_ as i32 && (
-            user_to_edit.type_ >= UserOrgType::Admin as i32 ||
-            new_type >= UserOrgType::Admin as i32
+            user_to_edit.type_ <= UserOrgType::Admin as i32 ||
+            new_type <= UserOrgType::Admin as i32
         ) &&
         headers.org_user_type != UserOrgType::Owner as i32 {
         err!("Only Owners can grant and remove Admin or Owner privileges")

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -408,11 +408,11 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
     Ok(())
 }
 
-#[post("/organizations/<org_id>/users/<user_id>/confirm", data = "<data>")]
-fn confirm_invite(org_id: String, user_id: String, data: JsonUpcase<Value>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+#[post("/organizations/<org_id>/users/<org_user_id>/confirm", data = "<data>")]
+fn confirm_invite(org_id: String, org_user_id: String, data: JsonUpcase<Value>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
     let data = data.into_inner().data;
 
-    let mut user_to_confirm = match UserOrganization::find_by_uuid(&user_id, &conn) {
+    let mut user_to_confirm = match UserOrganization::find_by_uuid(&org_user_id, &conn) {
         Some(user) => user,
         None => err!("Failed to find user membership")
     };
@@ -441,9 +441,9 @@ fn confirm_invite(org_id: String, user_id: String, data: JsonUpcase<Value>, head
     Ok(())
 }
 
-#[get("/organizations/<org_id>/users/<user_id>")]
-fn get_user(org_id: String, user_id: String, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
-    let user = match UserOrganization::find_by_uuid(&user_id, &conn) {
+#[get("/organizations/<org_id>/users/<org_user_id>")]
+fn get_user(org_id: String, org_user_id: String, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
+    let user = match UserOrganization::find_by_uuid(&org_user_id, &conn) {
         Some(user) => user,
         None => err!("Failed to find user membership")
     };
@@ -464,13 +464,13 @@ struct EditUserData {
     AccessAll: bool,
 }
 
-#[put("/organizations/<org_id>/users/<user_id>", data = "<data>", rank = 1)]
-fn put_organization_user(org_id: String, user_id: String, data: JsonUpcase<EditUserData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    edit_user(org_id, user_id, data, headers, conn)
+#[put("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
+fn put_organization_user(org_id: String, org_user_id: String, data: JsonUpcase<EditUserData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    edit_user(org_id, org_user_id, data, headers, conn)
 }
 
-#[post("/organizations/<org_id>/users/<user_id>", data = "<data>", rank = 1)]
-fn edit_user(org_id: String, user_id: String, data: JsonUpcase<EditUserData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+#[post("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
+fn edit_user(org_id: String, org_user_id: String, data: JsonUpcase<EditUserData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
     let data: EditUserData = data.into_inner().data;
 
     let new_type = match UserOrgType::from_str(&data.Type.into_string()) {
@@ -478,19 +478,22 @@ fn edit_user(org_id: String, user_id: String, data: JsonUpcase<EditUserData>, he
         None => err!("Invalid type")
     };
 
-    let mut user_to_edit = match UserOrganization::find_by_uuid(&user_id, &conn) {
+    let mut user_to_edit = match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn) {
         Some(user) => user,
         None => err!("The specified user isn't member of the organization")
     };
 
-    if new_type != UserOrgType::User as i32 &&
+    if new_type != user_to_edit.type_ as i32 && (
+            user_to_edit.type_ >= UserOrgType::Admin as i32 ||
+            new_type >= UserOrgType::Admin as i32
+        ) &&
         headers.org_user_type != UserOrgType::Owner as i32 {
-        err!("Only Owners can grant Admin or Owner type")
+        err!("Only Owners can grant and remove Admin or Owner privileges")
     }
 
-    if user_to_edit.type_ != UserOrgType::User as i32 &&
+    if user_to_edit.type_ == UserOrgType::Owner as i32 &&
         headers.org_user_type != UserOrgType::Owner as i32 {
-        err!("Only Owners can edit Admin or Owner")
+        err!("Only Owners can edit Owner users")
     }
 
     if user_to_edit.type_ == UserOrgType::Owner as i32 &&
@@ -535,9 +538,9 @@ fn edit_user(org_id: String, user_id: String, data: JsonUpcase<EditUserData>, he
     Ok(())
 }
 
-#[delete("/organizations/<org_id>/users/<user_id>")]
-fn delete_user(org_id: String, user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    let user_to_delete = match UserOrganization::find_by_uuid(&user_id, &conn) {
+#[delete("/organizations/<org_id>/users/<org_user_id>")]
+fn delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    let user_to_delete = match UserOrganization::find_by_uuid(&org_user_id, &conn) {
         Some(user) => user,
         None => err!("User to delete isn't member of the organization")
     };
@@ -564,7 +567,7 @@ fn delete_user(org_id: String, user_id: String, headers: AdminHeaders, conn: DbC
     }
 }
 
-#[post("/organizations/<org_id>/users/<user_id>/delete")]
-fn post_delete_user(org_id: String, user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    delete_user(org_id, user_id, headers, conn)
+#[post("/organizations/<org_id>/users/<org_user_id>/delete")]
+fn post_delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    delete_user(org_id, org_user_id, headers, conn)
 }

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -270,6 +270,13 @@ impl UserOrganization {
             .first::<Self>(&**conn).ok()
     }
 
+    pub fn find_by_uuid_and_org(uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
+        users_organizations::table
+            .filter(users_organizations::uuid.eq(uuid))
+            .filter(users_organizations::org_uuid.eq(org_uuid))
+            .first::<Self>(&**conn).ok()
+    }
+
     pub fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         users_organizations::table
             .filter(users_organizations::user_uuid.eq(user_uuid))


### PR DESCRIPTION
This fixes multiple issues:

1. [Make sure](https://github.com/mprasil/bitwarden_rs/blob/049aa33f179076a6b1ba3b71351b5d7b95ef4fdc/src/api/core/organizations.rs#L481) the user is actually member of organization we're managing.
2. Fix #163 by [allowing](https://github.com/mprasil/bitwarden_rs/blob/049aa33f179076a6b1ba3b71351b5d7b95ef4fdc/src/api/core/organizations.rs#L486-L497) admin users to edit other admin users.

    The implemented change allows admin users to change collection access for other admin users and themselves. Admin user is however not allowed to promote other users to Admin type or drop Admin privileges for other admin users.

3. Change `user_id` dynamic parameters to `org_user_id` as this better reflects the actual information that's provided.