### PR TITLE
Expose 3012 in docker build file for notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y\
 RUN mkdir /data
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (env file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -68,6 +68,7 @@ RUN apk add \
 RUN mkdir /data
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (env file and web-vault)
 # and the binary from the "build" stage to the current stage


### PR DESCRIPTION
This exposes the port required for the websocket and notifications support for the docker images.