### PR TITLE
Implement poor man's invitation via Organization invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _*Note, that this project is not associated with the [Bitwarden](https://bitward
   - [Updating the bitwarden image](#updating-the-bitwarden-image)
 - [Configuring bitwarden service](#configuring-bitwarden-service)
   - [Disable registration of new users](#disable-registration-of-new-users)
+  - [Disable invitations](#disable-invitations)
   - [Enabling HTTPS](#enabling-https)
   - [Enabling U2F authentication](#enabling-u2f-authentication)
   - [Changing persistent data location](#changing-persistent-data-location)
@@ -132,6 +133,20 @@ By default new users can register, if you want to disable that, set the `SIGNUPS
 ```sh
 docker run -d --name bitwarden \
   -e SIGNUPS_ALLOWED=false \
+  -v /bw-data/:/data/ \
+  -p 80:80 \
+  mprasil/bitwarden:latest
+```
+Note: While users can't register on their own, they can still be invited by already registered users. Read bellow if you also want to disable that.
+
+### Disable invitations
+
+Even when registration is disabled, organization administrators or owners can invite users to join organization. This won't send email invitation to the users, but after they are invited, they can register with the invited email even if `SIGNUPS_ALLOWED` is actually set to `false`. You can disable this functionality completely by setting `INVITATIONS_ALLOWED` env variable to `false`:
+
+```sh
+docker run -d --name bitwarden \
+  -e SIGNUPS_ALLOWED=false \
+  -e INVITATIONS_ALLOWED=false \
   -v /bw-data/:/data/ \
   -p 80:80 \
   mprasil/bitwarden:latest
@@ -365,7 +380,7 @@ We use upstream Vault interface directly without any (significant) changes, this
 
 ### Inviting users into organization
 
-The users must already be registered on your server to invite them, because we can't send the invitation via email. The invited users won't get the invitation email, instead they will appear in the interface as if they already accepted the invitation. Organization admin then just needs to confirm them to be proper Organization members and to give them access to the shared secrets.
+If you have [invitations disabled](#disable-invitations), the users must already be registered on your server to invite them. The invited users won't get the invitation email, instead they will appear in the interface as if they already accepted the invitation. (if the user has already registered) Organization admin then just needs to confirm them to be proper Organization members and to give them access to the shared secrets.
 
 ### Running on unencrypted connection
 

--- a/migrations/2018-09-10-111213_add_invites/down.sql
+++ b/migrations/2018-09-10-111213_add_invites/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE invitations;

--- a/migrations/2018-09-10-111213_add_invites/up.sql
+++ b/migrations/2018-09-10-111213_add_invites/up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE invitations (
+    email   TEXT NOT NULL PRIMARY KEY
+);

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -38,8 +38,6 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
                     user_org.status = UserOrgStatus::Accepted as i32;
                     user_org.save(&conn);
                 };
-                user.set_password(&data.MasterPasswordHash);
-                user.key = data.Key;
                 user
             } else {
                 if CONFIG.signups_allowed {
@@ -51,12 +49,15 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
         },
         None => {
             if CONFIG.signups_allowed || Invitation::take(&data.Email, &conn) {
-                User::new(data.Email, data.Key, data.MasterPasswordHash)
+                User::new(data.Email)
             } else {
                 err!("Registration not allowed")
             }
         }
     };
+
+    user.set_password(&data.MasterPasswordHash);
+    user.key = data.Key;
 
     // Add extra fields if present
     if let Some(name) = data.Name {

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -380,7 +380,7 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
                 let mut invitation = Invitation::new(email.clone());
                 match invitation.save(&conn) {
                     Ok(()) => {
-                        let mut user = User::new_invited(email.clone());
+                        let mut user = User::new(email.clone());
                         if user.save(&conn) {
                             user_org_status = UserOrgStatus::Invited as i32;
                             user

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use rocket_contrib::{Json, Value};
-
+use CONFIG;
 use db::DbConn;
 use db::models::*;
 
@@ -373,36 +373,56 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
         err!("Only Owners can invite Admins or Owners")
     }
 
-    for user_opt in data.Emails.iter().map(|email| User::find_by_mail(email, &conn)) {
-        match user_opt {
-            None => err!("User email does not exist"),
-            Some(user) => {
-                if UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn).is_some() {
-                    err!("User already in organization")
+    for email in data.Emails.iter() {
+        let mut user_org_status = UserOrgStatus::Accepted as i32;
+        let user = match User::find_by_mail(&email, &conn) {
+            None => if CONFIG.invitations_allowed { // Invite user if that's enabled
+                let mut invitation = Invitation::new(email.clone());
+                match invitation.save(&conn) {
+                    Ok(()) => {
+                        let mut user = User::new_invited(email.clone());
+                        if user.save(&conn) {
+                            user_org_status = UserOrgStatus::Invited as i32;
+                            user
+                        } else {
+                            err!("Failed to create placeholder for invited user")
+                        }
+                    }
+                    Err(_) => err!(format!("Failed to invite: {}", email))
                 }
+                
+            } else {
+                err!(format!("User email does not exist: {}", email))
+            },
+            Some(user) => if UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn).is_some() {
+                err!(format!("User already in organization: {}", email))
+            } else {
+                user
+            }
 
-                let mut new_user = UserOrganization::new(user.uuid.clone(), org_id.clone());
-                let access_all = data.AccessAll.unwrap_or(false);
-                new_user.access_all = access_all;
-                new_user.type_ = new_type;
+        };
 
-                // If no accessAll, add the collections received
-                if !access_all {
-                    for col in &data.Collections {
-                        match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn) {
-                            None => err!("Collection not found in Organization"),
-                            Some(collection) => {
-                                if CollectionUser::save(&user.uuid, &collection.uuid, col.ReadOnly, &conn).is_err() {
-                                    err!("Failed saving collection access for user")
-                                }
-                            }
+        let mut new_user = UserOrganization::new(user.uuid.clone(), org_id.clone());
+        let access_all = data.AccessAll.unwrap_or(false);
+        new_user.access_all = access_all;
+        new_user.type_ = new_type;
+        new_user.status = user_org_status;
+
+        // If no accessAll, add the collections received
+        if !access_all {
+            for col in &data.Collections {
+                match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn) {
+                    None => err!("Collection not found in Organization"),
+                    Some(collection) => {
+                        if CollectionUser::save(&user.uuid, &collection.uuid, col.ReadOnly, &conn).is_err() {
+                            err!("Failed saving collection access for user")
                         }
                     }
                 }
-
-                new_user.save(&conn);
             }
         }
+
+        new_user.save(&conn);
     }
 
     Ok(())

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -12,7 +12,7 @@ pub use self::attachment::Attachment;
 pub use self::cipher::Cipher;
 pub use self::device::Device;
 pub use self::folder::{Folder, FolderCipher};
-pub use self::user::User;
+pub use self::user::{User, Invitation};
 pub use self::organization::Organization;
 pub use self::organization::{UserOrganization, UserOrgStatus, UserOrgType};
 pub use self::collection::{Collection, CollectionUser, CollectionCipher};

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -27,7 +27,7 @@ pub struct UserOrganization {
 }
 
 pub enum UserOrgStatus {
-    _Invited = 0, // Unused, users are accepted automatically
+    Invited = 0,
     Accepted = 1,
     Confirmed = 2,
 }
@@ -281,6 +281,13 @@ impl UserOrganization {
         users_organizations::table
             .filter(users_organizations::user_uuid.eq(user_uuid))
             .filter(users_organizations::status.eq(UserOrgStatus::Confirmed as i32))
+            .load::<Self>(&**conn).unwrap_or(vec![])
+    }
+
+    pub fn find_invited_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+        users_organizations::table
+            .filter(users_organizations::user_uuid.eq(user_uuid))
+            .filter(users_organizations::status.eq(UserOrgStatus::Invited as i32))
             .load::<Self>(&**conn).unwrap_or(vec![])
     }
 

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -39,13 +39,12 @@ pub struct User {
 
 /// Local methods
 impl User {
-    pub fn new(mail: String, key: String, password: String) -> Self {
+    pub fn new(mail: String) -> Self {
         let now = Utc::now().naive_utc();
         let email = mail.to_lowercase();
 
         let iterations = CONFIG.password_iterations;
         let salt = crypto::get_random_64();
-        let password_hash = crypto::hash_password(password.as_bytes(), &salt, iterations as u32);
 
         Self {
             uuid: Uuid::new_v4().to_string(),
@@ -53,9 +52,9 @@ impl User {
             updated_at: now,
             name: email.clone(),
             email,
-            key,
+            key: String::new(),
 
-            password_hash,
+            password_hash: Vec::new(),
             salt,
             password_iterations: iterations,
 
@@ -71,10 +70,6 @@ impl User {
             equivalent_domains: "[]".to_string(),
             excluded_globals: "[]".to_string(),
         }
-    }
-
-    pub fn new_invited(mail: String) -> Self {
-        Self::new(mail,"".to_string(),"".to_string())
     }
 
     pub fn check_valid_password(&self, password: &str) -> bool {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -114,6 +114,12 @@ table! {
 }
 
 table! {
+    invitations (email) {
+        email -> Text,
+    }
+}
+
+table! {
     users_collections (user_uuid, collection_uuid) {
         user_uuid -> Text,
         collection_uuid -> Text,

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,7 @@ pub struct Config {
 
     local_icon_extractor: bool,
     signups_allowed: bool,
+    invitations_allowed: bool,
     password_iterations: i32,
     show_password_hint: bool,
     domain: String,
@@ -199,6 +200,7 @@ impl Config {
 
             local_icon_extractor: util::parse_option_string(env::var("LOCAL_ICON_EXTRACTOR").ok()).unwrap_or(false),
             signups_allowed: util::parse_option_string(env::var("SIGNUPS_ALLOWED").ok()).unwrap_or(true),
+            invitations_allowed: util::parse_option_string(env::var("INVITATIONS_ALLOWED").ok()).unwrap_or(true),
             password_iterations: util::parse_option_string(env::var("PASSWORD_ITERATIONS").ok()).unwrap_or(100_000),
             show_password_hint: util::parse_option_string(env::var("SHOW_PASSWORD_HINT").ok()).unwrap_or(true),
 


### PR DESCRIPTION
This should allow invitation-only registration via Organization invitations. The way it works follows the suggested approach [outlined](https://github.com/dani-garcia/bitwarden_rs/issues/40#issue-331759674) in #40. When Admin/Owner invites user with an email that is not found, a new record in `invitations` table is created. At the same time an `User` is created with random password and key generated just as a "placeholder".

When user tries to register, they will be allowed to do so even if SIGNUPS_ALLOWED is set to false if their email is in the invitations table.

This should also allow user to register without the placeholder `User` already being present, which would accommodate some external integration like the one [suggested](https://github.com/dani-garcia/bitwarden_rs/issues/40#issuecomment-405399443) by @ViViDboarder. But we'd have to document that kind of usage.