### PR TITLE
Add continuation token when we return object list

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -57,6 +57,7 @@ fn get_ciphers(headers: Headers, conn: DbConn) -> JsonResult {
     Ok(Json(json!({
       "Data": ciphers_json,
       "Object": "list",
+      "ContinuationToken": null
     })))
 }
 

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -16,6 +16,7 @@ fn get_folders(headers: Headers, conn: DbConn) -> JsonResult {
     Ok(Json(json!({
       "Data": folders_json,
       "Object": "list",
+      "ContinuationToken": null,
     })))
 }
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -141,7 +141,8 @@ fn get_user_collections(headers: Headers, conn: DbConn) -> JsonResult {
             .iter()
             .map(Collection::to_json)
             .collect::<Value>(),
-        "Object": "list"
+        "Object": "list",
+        "ContinuationToken": null,
     })))
 }
 
@@ -153,7 +154,8 @@ fn get_org_collections(org_id: String, _headers: AdminHeaders, conn: DbConn) -> 
             .iter()
             .map(Collection::to_json)
             .collect::<Value>(),
-        "Object": "list"
+        "Object": "list",
+        "ContinuationToken": null,
     })))
 }
 
@@ -294,7 +296,8 @@ fn get_collection_users(org_id: String, coll_id: String, _headers: AdminHeaders,
 
     Ok(Json(json!({
         "Data": user_list,
-        "Object": "list"
+        "Object": "list",
+        "ContinuationToken": null,
     })))
 }
 
@@ -312,6 +315,7 @@ fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> JsonResul
     Ok(Json(json!({
       "Data": ciphers_json,
       "Object": "list",
+      "ContinuationToken": null,
     })))
 }
 
@@ -327,7 +331,8 @@ fn get_org_users(org_id: String, headers: AdminHeaders, conn: DbConn) -> JsonRes
 
     Ok(Json(json!({
         "Data": users_json,
-        "Object": "list"
+        "Object": "list",
+        "ContinuationToken": null,
     })))
 }
 

--- a/src/api/core/two_factor.rs
+++ b/src/api/core/two_factor.rs
@@ -19,7 +19,8 @@ fn get_twofactor(headers: Headers, conn: DbConn) -> JsonResult {
 
     Ok(Json(json!({
         "Data": twofactors_json,
-        "Object": "list"
+        "Object": "list",
+        "ContinuationToken": null,
     })))
 }
 


### PR DESCRIPTION
This sends `"ContinuationToken": null` every time we send `"Object": "list"` as it looks like Vault can get confused when such field isn't present. 