### PR TITLE
Return proper error message for org reinvite

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -112,6 +112,7 @@ pub fn routes() -> Vec<Route> {
         put_organization_user,
         delete_user,
         post_delete_user,
+        post_reinvite_user,
         post_org_import,
 
         clear_device_token,

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -592,6 +592,11 @@ fn post_delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, 
     delete_user(org_id, org_user_id, headers, conn)
 }
 
+#[post("/organizations/<_org_id>/users/<_org_user_id>/reinvite")]
+fn post_reinvite_user(_org_id: String, _org_user_id: String, _headers: AdminHeaders, _conn: DbConn) -> EmptyResult {
+    err!("This functionality is not implemented. The user needs to manually register before they can be accepted into the organization.")
+}
+
 use super::ciphers::CipherData;
 use super::ciphers::update_cipher_from_data;
 


### PR DESCRIPTION
Fixes #188.

Displays an error message in the log when the user clicks the `Resend invitation` option for a user on the Organization/People admin panel.