### PR TITLE
Implement poor man's admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _*Note, that this project is not associated with the [Bitwarden](https://bitward
 - [Configuring bitwarden service](#configuring-bitwarden-service)
   - [Disable registration of new users](#disable-registration-of-new-users)
   - [Disable invitations](#disable-invitations)
+  - [Configure server administrator](#configure-server-administrator)
   - [Enabling HTTPS](#enabling-https)
   - [Enabling WebSocket notifications](#enabling-websocket-notifications)
   - [Enabling U2F authentication](#enabling-u2f-authentication)
@@ -154,6 +155,21 @@ docker run -d --name bitwarden \
   -p 80:80 \
   mprasil/bitwarden:latest
 ```
+### Configure server administrator
+
+You can configure one email account to be server administrator via the `SERVER_ADMIN_EMAIL` environment variable:
+
+```sh
+docker run -d --name bitwarden \
+  -e SERVER_ADMIN_EMAIL=admin@example.com \
+  -v /bw-data/:/data/ \
+  -p 80:80 \
+  mprasil/bitwarden:latest
+```
+
+This will give the user extra functionality and privileges to manage users on the server. In the Vault, the user will see a special (virtual) organization called `bitwarden_rs`. This organization doesn't actually exist and can't be used for most things. (can't have collections or ciphers) Instead it just contains all the users registered on the server. Deleting users from this organization will actually completely delete the user from the server. Inviting users into this organization will just invite the user so they are able to register, but will not grant any organization membership. (unlike inviting user to regular organization)
+
+You can think of the `bitwarden_rs` organization as sort of Admin interface to manage users on the server. Due to the virtual nature of this organization, it is missing some internal data structures and most of the functionality. It is thus strongly recommended to use dedicated account for `SERVER_ADMIN_EMAIL` and this account shouldn't be used for actually storing passwords. Also keep in mind that deleting user this way removes the user permanently without any way to restore the deleted data just as if user deleted their own account.
 
 ### Enabling HTTPS
 To enable HTTPS, you need to configure the `ROCKET_TLS`.

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -288,28 +288,11 @@ fn delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn
     if !user.check_valid_password(&data.MasterPasswordHash) {
         err!("Invalid password")
     }
-
-    // Delete ciphers and their attachments
-    for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
-        if cipher.delete(&conn).is_err() {
-            err!("Failed deleting cipher")
-        }
+    
+    match user.delete(&conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Failed deleting user account, are you the only owner of some organization?")
     }
-
-    // Delete folders
-    for f in Folder::find_by_user(&user.uuid, &conn) {
-        if f.delete(&conn).is_err() {
-            err!("Failed deleting folder")
-        } 
-    }
-
-    // Delete devices
-    for d in Device::find_by_user(&user.uuid, &conn) { d.delete(&conn); }
-
-    // Delete user
-    user.delete(&conn);
-
-    Ok(())
 }
 
 #[get("/accounts/revision-date")]

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -151,9 +151,10 @@ fn clear_device_token(uuid: String, data: Json<Value>, headers: Headers, conn: D
         err!("Device not owned by user")
     }
 
-    device.delete(&conn);
-
-    Ok(())
+    match device.delete(&conn) {
+        Ok(()) => Ok(()),
+        Err(_) => err!("Failed deleting device")
+    }
 }
 
 #[put("/devices/identifier/<uuid>/token", data = "<data>")]

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -107,11 +107,13 @@ fn _password_login(data: &ConnectData, device_type: DeviceType, conn: DbConn, re
         Some(device) => {
             // Check if valid device
             if device.user_uuid != user.uuid {
-                device.delete(&conn);
-                err!("Device is not owned by user")
+                match device.delete(&conn) {
+                    Ok(()) => Device::new(device_id, user.uuid.clone(), device_name, device_type_num),
+                    Err(_) => err!("Tried to delete device not owned by user, but failed")
+                }
+            } else {
+                device
             }
-
-            device
         }
         None => {
             // Create new device

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -95,7 +95,7 @@ use rocket::Outcome;
 use rocket::request::{self, Request, FromRequest};
 
 use db::DbConn;
-use db::models::{User, UserOrganization, UserOrgType, UserOrgStatus, Device};
+use db::models::{User, Organization, UserOrganization, UserOrgType, UserOrgStatus, Device};
 
 pub struct Headers {
     pub host: String,
@@ -212,7 +212,13 @@ impl<'a, 'r> FromRequest<'a, 'r> for OrgHeaders {
                                     err_handler!("The current user isn't confirmed member of the organization")
                                 }
                             }
-                            None => err_handler!("The current user isn't member of the organization")
+                            None => {
+                                if headers.user.is_server_admin() && org_id == Organization::VIRTUAL_ID {
+                                    UserOrganization::new_virtual(headers.user.uuid.clone(), UserOrgType::Owner, UserOrgStatus::Confirmed)
+                                } else {
+                                    err_handler!("The current user isn't member of the organization")
+                                }
+                            }
                         };
 
                         Outcome::Success(Self{

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -182,6 +182,13 @@ impl Cipher {
         Ok(())
     }
 
+    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        for cipher in Self::find_owned_by_user(user_uuid, &conn) {
+            cipher.delete(&conn)?;
+        }
+        Ok(())
+    }
+
     pub fn move_to_folder(&self, folder_uuid: Option<String>, user_uuid: &str, conn: &DbConn) -> Result<(), &str> {
         match self.get_folder_uuid(&user_uuid, &conn)  {
             None => {

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -123,13 +123,17 @@ impl Device {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> bool {
-        match diesel::delete(devices::table.filter(
-            devices::uuid.eq(self.uuid)))
-            .execute(&**conn) {
-            Ok(1) => true, // One row deleted
-            _ => false,
+    pub fn delete(self, conn: &DbConn) -> QueryResult<()> {
+        diesel::delete(devices::table.filter(
+            devices::uuid.eq(self.uuid)
+        )).execute(&**conn).and(Ok(()))
+    }
+
+    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        for device in Self::find_by_user(user_uuid, &conn) {
+            device.delete(&conn)?;
         }
+        Ok(())
     }
 
     pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {

--- a/src/db/models/folder.rs
+++ b/src/db/models/folder.rs
@@ -93,6 +93,13 @@ impl Folder {
         ).execute(&**conn).and(Ok(()))
     }
 
+    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> QueryResult<()> {
+        for folder in Self::find_by_user(user_uuid, &conn) {
+            folder.delete(&conn)?;
+        }
+        Ok(())
+    }
+
     pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         folders::table
             .filter(folders::uuid.eq(uuid))

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,7 @@ pub struct Config {
     local_icon_extractor: bool,
     signups_allowed: bool,
     invitations_allowed: bool,
+    server_admin_email: Option<String>,
     password_iterations: i32,
     show_password_hint: bool,
 
@@ -272,6 +273,7 @@ impl Config {
 
             local_icon_extractor: get_env_or("LOCAL_ICON_EXTRACTOR", false),
             signups_allowed: get_env_or("SIGNUPS_ALLOWED", true),
+            server_admin_email: get_env("SERVER_ADMIN_EMAIL"),
             invitations_allowed: get_env_or("INVITATIONS_ALLOWED", true),
             password_iterations: get_env_or("PASSWORD_ITERATIONS", 100_000),
             show_password_hint: get_env_or("SHOW_PASSWORD_HINT", true),


### PR DESCRIPTION
This enables you to configure one email account to be server administrator via the `SERVER_ADMIN_EMAIL` environment variable. This will give the user extra functionality and privileges to manage users on the server. In the Vault, the user will see a special (virtual) organization called `bitwarden_rs`. Deleting users from this organization will actually completely delete the user from the server. Inviting users into this organization will just invite the user so they are able to register, but will not grant any organization membership.

This should hopefully cover use cases like the one in #212 and #202 without actually creating the admin panel. 
