### PR TITLE
Fix /sync without query string

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -53,6 +53,13 @@ fn sync(data: SyncData, headers: Headers, conn: DbConn) -> JsonResult {
     })))
 }
 
+#[get("/sync")]
+fn sync_no_query(headers: Headers, conn: DbConn) -> JsonResult {
+    let sync_data = SyncData {
+        excludeDomains: false,
+    };
+    sync(sync_data, headers, conn)
+}
 
 #[get("/ciphers")]
 fn get_ciphers(headers: Headers, conn: DbConn) -> JsonResult {

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -30,6 +30,7 @@ pub fn routes() -> Vec<Route> {
         prelogin,
 
         sync,
+        sync_no_query,
 
         get_ciphers,
         get_cipher,


### PR DESCRIPTION
Due to Rocket being a bit weird with query strings currently (see [this Rocket issue](https://github.com/SergioBenitez/Rocket/issues/376)), my last change (#225) broke clients which call `/sync` without the `?excludeDomains=` query string. At least the Firefox addon is affected.
Until Rocket releases their new query string parsing logic [implemented here](https://github.com/SergioBenitez/Rocket/issues/608) in `0.4.0`, we're probably stuck with this rather ugly workaround.