### PR TITLE
Update PROXY.md

### DIFF
--- a/PROXY.md
+++ b/PROXY.md
@@ -31,25 +31,24 @@ localhost:443 {
 ## Nginx (by shauder)
 ```nginx
 server {
-  include conf.d/ssl/ssl.conf;
-
   listen 443 ssl http2;
   server_name vault.*;
-
-  location /notifications/hub/negotiate {
-    include conf.d/proxy-confs/proxy.conf;
-    proxy_pass http://<SERVER>:80;
-  }
-
+  
+  # Specify SSL config if using a shared one.
+  #include conf.d/ssl/ssl.conf;
+  
   location / {
-    include conf.d/proxy-confs/proxy.conf;
     proxy_pass http://<SERVER>:80;
   }
-
+  
   location /notifications/hub {
     proxy_pass http://<SERVER>:3012;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+  }
+  
+  location /notifications/hub/negotiate {
+    proxy_pass http://<SERVER>:80;
   }
 }
 ```


### PR DESCRIPTION
Removed: `include conf.d/proxy-confs/proxy.conf;` lines because they're specific to user (shauder) and will break nginx if copy-pasted/don't exist.
Changed: Moved listen value and server_name to top as is standard for nginx configs
Changed: Commented out SSL config as it's specific to user (shauder) and will break if copy-pasted/don't exist. But is still useful and a good idea for simplifying nginx config.
Changed: Rearranged location blocks because OCD. First /, then /notifications/hub, then /notifications/hub/negotiate because it looks nicer in a tree where each location grows.