### PR TITLE
Switch from resin to balenalib

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -80,7 +80,7 @@ RUN cargo build --release --target=aarch64-unknown-linux-gnu -v
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM resin/aarch64-debian:stretch
+FROM balenalib/aarch64-debian:stretch
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_WORKERS=10

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -80,7 +80,7 @@ RUN cargo build --release --target=armv7-unknown-linux-gnueabihf -v
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM resin/armv7hf-debian:stretch
+FROM balenalib/armv7hf-debian:stretch
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_WORKERS=10


### PR DESCRIPTION
We used resin base images for raspberry images. Resin is now discontinued in favour of balenalib.