### PR TITLE
Make U2F work with vault 2.4.0 changes

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -80,6 +80,7 @@ pub fn routes() -> Vec<Route> {
         activate_authenticator,
         activate_authenticator_put,
         generate_u2f,
+        generate_u2f_challenge,
         activate_u2f,
         activate_u2f_put,
 

--- a/src/api/core/two_factor.rs
+++ b/src/api/core/two_factor.rs
@@ -273,6 +273,34 @@ fn generate_u2f(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) 
     })))
 }
 
+#[post("/two-factor/get-u2f-challenge", data = "<data>")]
+fn generate_u2f_challenge(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+    let data: PasswordData = data.into_inner().data;
+
+    if !headers.user.check_valid_password(&data.MasterPasswordHash) {
+        err!("Invalid password");
+    }
+
+    let user_uuid = &headers.user.uuid;
+
+    let u2f_type = TwoFactorType::U2f as i32;
+    let register_type = TwoFactorType::U2fRegisterChallenge;
+    let (enabled, challenge) = match TwoFactor::find_by_user_and_type(user_uuid, u2f_type, &conn) {
+        Some(_) => (true, String::new()),
+        None => {
+            let c = _create_u2f_challenge(user_uuid, register_type, &conn);
+            (false, c.challenge)
+        }
+    };
+
+    Ok(Json(json!({
+        "UserId": headers.user.uuid,
+        "AppId": APP_ID.to_string(),
+        "Challenge": challenge,
+        "Version": U2F_VERSION,
+    })))
+}
+
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
 struct EnableU2FData {

--- a/src/api/core/two_factor.rs
+++ b/src/api/core/two_factor.rs
@@ -252,23 +252,10 @@ fn generate_u2f(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) 
     let user_uuid = &headers.user.uuid;
 
     let u2f_type = TwoFactorType::U2f as i32;
-    let register_type = TwoFactorType::U2fRegisterChallenge;
-    let (enabled, challenge) = match TwoFactor::find_by_user_and_type(user_uuid, u2f_type, &conn) {
-        Some(_) => (true, String::new()),
-        None => {
-            let c = _create_u2f_challenge(user_uuid, register_type, &conn);
-            (false, c.challenge)
-        }
-    };
+    let enabled = TwoFactor::find_by_user_and_type(user_uuid, u2f_type, &conn).is_some();
 
     Ok(Json(json!({
         "Enabled": enabled,
-        "Challenge": {
-            "UserId": headers.user.uuid,
-            "AppId": APP_ID.to_string(),
-            "Challenge": challenge,
-            "Version": U2F_VERSION,
-        },
         "Object": "twoFactorU2f"
     })))
 }
@@ -283,15 +270,7 @@ fn generate_u2f_challenge(data: JsonUpcase<PasswordData>, headers: Headers, conn
 
     let user_uuid = &headers.user.uuid;
 
-    let u2f_type = TwoFactorType::U2f as i32;
-    let register_type = TwoFactorType::U2fRegisterChallenge;
-    let (enabled, challenge) = match TwoFactor::find_by_user_and_type(user_uuid, u2f_type, &conn) {
-        Some(_) => (true, String::new()),
-        None => {
-            let c = _create_u2f_challenge(user_uuid, register_type, &conn);
-            (false, c.challenge)
-        }
-    };
+    let challenge = _create_u2f_challenge(user_uuid, TwoFactorType::U2fRegisterChallenge, &conn).challenge;
 
     Ok(Json(json!({
         "UserId": headers.user.uuid,


### PR DESCRIPTION
The Bitwarden API for u2f enrollment changed. Specifically, challenge generate was removed from `/api/two-factor/get-u2f` in to `/api/two-factor/get-u2f-challenge`. 

Presently, this PR restores the minimal functionality, but the desire is to implement multi-enrollment.

RE: #235 