### PR TITLE
Fixes NFC Response for Mobile Yubikey OTP Login

### DIFF
--- a/src/api/core/two_factor.rs
+++ b/src/api/core/two_factor.rs
@@ -507,9 +507,9 @@ struct EnableYubikeyData {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[allow(non_snake_case)]
-struct YubikeyMetadata {
+pub struct YubikeyMetadata {
     Keys: Vec<String>,
-    Nfc: bool,
+    pub Nfc: bool,
 }
 
 use yubico::Yubico;

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -269,6 +269,19 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
                 result["TwoFactorProviders2"][provider.to_string()] = Value::Object(map);
             }
 
+            Some(TwoFactorType::YubiKey) => {
+                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, TwoFactorType::YubiKey as i32, &conn) {
+                    Some(tf) => tf,
+                    None => err!("No YubiKey devices registered"),
+                };
+
+                let yubikey_metadata: two_factor::YubikeyMetadata = serde_json::from_str(&twofactor.data).expect("Can't parse Yubikey Metadata");
+
+                let mut map = JsonMap::new();
+                map.insert("Nfc".into(), Value::Bool(yubikey_metadata.Nfc));
+                result["TwoFactorProviders2"][provider.to_string()] = Value::Object(map);
+            }
+
             _ => {}
         }
     }


### PR DESCRIPTION
With Yubikey OTP introduced in #254, it doesn't return whether Nfc should be enabled to the mobile client during login. As a result, the mobile client crashes upon login.

This PR returns the proper NFC value saved by the user in 2FA Yubikey OTP settings.

