### PR TITLE
Update backup section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ This command can be run via a CRON job everyday, however note that it will overw
 
 Running the above command requires sqlite3 to be installed on the docker host system. You can achieve the same result with a sqlite3 docker container using the following command.
 ```
-docker run --rm --volumes-from=bitwarden registry.gitlab.com/1o/bitwarden_rs-backup/bw_backup /backup.sh"
+docker run --rm --volumes-from=bitwarden bruceforce/bw_backup /backup.sh
 ```
 
 You can also run a container with integrated cron daemon to automatically backup your database. See https://gitlab.com/1O/bitwarden_rs-backup for examples.

--- a/README.md
+++ b/README.md
@@ -430,10 +430,18 @@ It will setup a fully functional and secure `bitwarden_rs` application in Kubern
 The sqlite3 database should be backed up using the proper sqlite3 backup command. This will ensure the database does not become corrupted if the backup happens during a database write.
 
 ```
+mkdir $DATA_FOLDER/db-backup
 sqlite3 /$DATA_FOLDER/db.sqlite3 ".backup '/$DATA_FOLDER/db-backup/backup.sqlite3'"
 ```
 
-This command can be run via a CRON job everyday, however note that it will overwrite the same `backup.sqlite3` file each time. This backup file should therefore be saved via incremental backup either using a CRON job command that appends a timestamp or from another backup app such as Duplicati. To restore simply overwrite `db.sqlite3` with `backup.sqlite3` (while bitwarden_rs is stopped).
+This command can be run via a CRON job everyday, however note that it will overwrite the same `backup.sqlite3` file each time. This backup file should therefore be saved via incremental backup either using a CRON job command that appends a timestamp or from another backup app such as Duplicati. To restore simply overwrite `db.sqlite3` with `backup.sqlite3` (while bitwarden_rs is stopped). 
+
+Running the above command requires sqlite3 to be installed on the docker host system. You can achieve the same result with a sqlite3 docker container using the following command.
+```
+docker run --rm --volumes-from=bitwarden registry.gitlab.com/1o/bitwarden_rs-backup/bw_backup /backup.sh"
+```
+
+You can also run a container with integrated cron daemon to automatically backup your database. See https://gitlab.com/1O/bitwarden_rs-backup for examples.
  
 ### 2. the attachments folder
 


### PR DESCRIPTION
As discussed in #247 it would be nice if the documentation describes a way to do a backup of the database without installing sqlite to the host system. I also added the mkdir in Line 450 because it doesn't exist in the first place.