### PR TITLE
Update dockerfile for alpine, armv7 and aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -39,14 +39,7 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
-# Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Copies over *only* your manifests and vendored dependencies
-COPY ./Cargo.* ./
-COPY ./libs ./libs
-COPY ./rust-toolchain ./rust-toolchain
 
 # Prepare openssl arm64 libs
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
@@ -62,19 +55,12 @@ ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
 
-# Builds your dependencies and removes the
-# dummy project, except the target folder
-# This folder contains the compiled dependencies
-RUN rustup target add aarch64-unknown-linux-gnu
-RUN cargo build --release --target=aarch64-unknown-linux-gnu -v
-RUN find . -not -path "./target*" -delete
-
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Builds again, this time it'll just be
-# your actual source files being built
+# Build
+RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --release --target=aarch64-unknown-linux-gnu -v
 
 ######################## RUNTIME IMAGE  ########################

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,28 +26,17 @@ RUN npm run dist \
 
 ########################## BUILD IMAGE  ##########################
 # Musl build image for statically compiled binary
-FROM clux/muslrust:nightly-2018-08-24 as build
+FROM clux/muslrust:nightly-2018-10-03 as build
 
-# Creates a dummy project used to grab dependencies
-RUN USER=root cargo init --bin
+ENV USER "root"
 
-# Copies over *only* your manifests and vendored dependencies
-COPY ./Cargo.* ./
-COPY ./libs ./libs
-COPY ./rust-toolchain ./rust-toolchain
-
-# Builds your dependencies and removes the
-# dummy project, except the target folder
-# This folder contains the compiled dependencies
-RUN cargo build --release
-RUN find . -not -path "./target*" -delete
+WORKDIR /app
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Builds again, this time it'll just be
-# your actual source files being built
+# Build
 RUN cargo build --release
 
 ######################## RUNTIME IMAGE  ########################

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -39,14 +39,7 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
-# Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Copies over *only* your manifests and vendored dependencies
-COPY ./Cargo.* ./
-COPY ./libs ./libs
-COPY ./rust-toolchain ./rust-toolchain
 
 # Prepare openssl armhf libs
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
@@ -62,19 +55,12 @@ ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
 
-# Builds your dependencies and removes the
-# dummy project, except the target folder
-# This folder contains the compiled dependencies
-RUN rustup target add armv7-unknown-linux-gnueabihf
-RUN cargo build --release --target=armv7-unknown-linux-gnueabihf -v
-RUN find . -not -path "./target*" -delete
-
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Builds again, this time it'll just be
-# your actual source files being built
+# Build
+RUN rustup target add armv7-unknown-linux-gnueabihf
 RUN cargo build --release --target=armv7-unknown-linux-gnueabihf -v
 
 ######################## RUNTIME IMAGE  ########################


### PR DESCRIPTION
This updates the alpine Dockerfile to fix #259, it also simplifies the Dockerfiles for alpine, raspberry and aarch64 to build a little bit faster on docker hub. 