### PR TITLE
Close #264. Username and IP address is logged on successful authentication

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -129,6 +129,7 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: ClientIp) -> JsonResult 
         result["TwoFactorToken"] = Value::String(token);
     }
 
+    info!("User {} logged in successfully. IP: {}", username, ip.ip);
     Ok(Json(result))
 }
 


### PR DESCRIPTION
Closes #264 by using the new rocket logging features to write IP addresses and usernames to logs on a successful login.