### PR TITLE
Add Email Invite Functionality

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -21,6 +21,8 @@ A compiled version of the web vault can be downloaded from [dani-garcia/bw_web_b
 
 If you prefer to compile it manually, follow these steps:
 
+*Note: building the Vault needs ~1.5GB of RAM. On systems like a RaspberryPI with 1GB or less, please [enable swapping](https://www.tecmint.com/create-a-linux-swap-file/) or build it on a more powerful machine and copy the directory from there. This much memory is only needed for building it, running bitwarden_rs with vault needs only about 10MB of RAM.*
+
 - Clone the git repository at [bitwarden/web](https://github.com/bitwarden/web) and checkout the latest release tag (e.g. v2.1.1):
 ```sh
 # clone the repository
@@ -37,6 +39,7 @@ git apply /path/to/bitwarden_rs/docker/set-vault-baseurl.patch
 ```
 
 - Then, build the Vault:
+
 ```sh
 npm run sub:init
 npm install

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,7 +20,7 @@ RUN ls
 
 ########################## BUILD IMAGE  ##########################
 # Musl build image for statically compiled binary
-FROM clux/muslrust:nightly-2018-11-30 as build
+FROM clux/muslrust:nightly-2018-12-01 as build
 
 ENV USER "root"
 
@@ -29,6 +29,8 @@ WORKDIR /app
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
+
+RUN rustup target add x86_64-unknown-linux-musl
 
 # Build
 RUN cargo build --release

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -74,7 +74,6 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
                     err!("Registration not allowed")
                 }
             } else {
-                // User clicked email invite link, so they are already "accepted" in UserOrgs
                 user
             }
         }

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -59,7 +59,7 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
 
     let mut user = match User::find_by_mail(&data.Email, &conn) {
         Some(user) => {
-            if !CONFIG.email_invitations {
+            if CONFIG.mail.is_none() {
                 if Invitation::take(&data.Email, &conn) {
                     for mut user_org in UserOrganization::find_invited_by_user(&user.uuid, &conn).iter_mut() {
                         user_org.status = UserOrgStatus::Accepted as i32;
@@ -79,7 +79,7 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
             }
         }
         None => {
-            if CONFIG.signups_allowed || (!CONFIG.email_invitations && Invitation::take(&data.Email, &conn)) {
+            if CONFIG.signups_allowed || (CONFIG.mail.is_none() && Invitation::take(&data.Email, &conn)) {
                 User::new(data.Email)
             } else {
                 err!("Registration not allowed")

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -479,7 +479,7 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
             }
         }
 
-        if CONFIG.email_invitations {
+        if CONFIG.mail.is_some() {
             use crate::mail;
             use chrono::{Duration, Utc};
             let time_now = Utc::now().naive_utc();

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -520,8 +520,9 @@ struct AcceptData {
     Token: String,
 }
 
-#[post("/organizations/<org_id>/users/<org_user_id>/accept", data = "<data>")]
-fn accept_invite(org_id: String, org_user_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) -> EmptyResult {
+#[post("/organizations/<_org_id>/users/<_org_user_id>/accept", data = "<data>")]
+fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) -> EmptyResult {
+// The web-vault passes org_id and org_user_id in the URL, but we are just reading them from the JWT instead
     let data: AcceptData = data.into_inner().data;
     let token = &data.Token;
     let claims: InviteJWTClaims = match decode_invite_jwt(&token) {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -120,6 +120,8 @@ pub struct InviteJWTClaims {
     pub sub: String,
 
     pub email: String,
+    pub org_id: String,
+    pub user_org_id: Option<String>,
 }
 
 ///

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -56,6 +56,27 @@ pub fn decode_jwt(token: &str) -> Result<JWTClaims, String> {
     }
 }
 
+pub fn decode_invite_jwt(token: &str) -> Result<InviteJWTClaims, String> {
+    let validation = jsonwebtoken::Validation {
+        leeway: 30, // 30 seconds
+        validate_exp: true,
+        validate_iat: false, // IssuedAt is the same as NotBefore
+        validate_nbf: true,
+        aud: None,
+        iss: Some(JWT_ISSUER.clone()),
+        sub: None,
+        algorithms: vec![JWT_ALGORITHM],
+    };
+
+    match jsonwebtoken::decode(token, &PUBLIC_RSA_KEY, &validation) {
+        Ok(decoded) => Ok(decoded.claims),
+        Err(msg) => {
+            error!("Error validating jwt - {:#?}", msg);
+            Err(msg.to_string())
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JWTClaims {
     // Not before
@@ -85,6 +106,20 @@ pub struct JWTClaims {
     pub scope: Vec<String>,
     // [ "Application" ]
     pub amr: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InviteJWTClaims {
+    // Not before
+    pub nbf: i64,
+    // Expiration time
+    pub exp: i64,
+    // Issuer
+    pub iss: String,
+    // Subject
+    pub sub: String,
+
+    pub email: String,
 }
 
 ///

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -68,10 +68,10 @@ pub fn send_invite(address: &str, org_id: &str, org_user_id: &str, token: &str, 
         format!(
             "<html>
              <p>You have been invited to join the <b>{}</b> organization.<br><br>
-             <a href=\"https://{}/api/organizations/{}/users/{}/accept?token={}\">Click here to join</a></p>
+             <a href=\"{}/#/accept-organization/?organizationId={}&organizationUserId={}&email={}&organizationName={}&token={}\">Click here to join</a></p>
              <p>If you do not wish to join this organization, you can safely ignore this email.</p>
              </html>",
-            org_name, CONFIG.domain, org_id, org_user_id, token
+            org_name, CONFIG.domain, org_id, org_user_id, address, org_name, token
         ))
     };
 

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -5,6 +5,7 @@ use lettre::smtp::authentication::Credentials;
 use lettre_email::EmailBuilder;
 
 use crate::MailConfig;
+use crate::CONFIG;
 
 fn mailer(config: &MailConfig) -> SmtpTransport {
     let client_security = if config.smtp_ssl {
@@ -51,6 +52,34 @@ pub fn send_password_hint(address: &str, hint: Option<String>, config: &MailConf
         .to(address)
         .from((config.smtp_from.clone(), "Bitwarden-rs"))
         .subject(subject)
+        .body(body)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    mailer(config)
+        .send(email.into())
+        .map_err(|e| e.to_string())
+        .and(Ok(()))
+}
+
+pub fn send_invite(address: &str, org_id: &str, org_user_id: &str, token: &str, org_name: &str, config: &MailConfig) -> Result<(), String> {
+    let (subject, body) =  {
+        (format!("Join {}", &org_name),
+        format!(
+            "<html>
+             <p>You have been invited to join the <b>{}</b> organization.<br><br>
+             <a href=\"https://{}/api/organizations/{}/users/{}/accept?token={}\">Click here to join</a></p>
+             <p>If you do not wish to join this organization, you can safely ignore this email.</p>
+             </html>",
+            org_name, CONFIG.domain, org_id, org_user_id, token
+        ))
+    };
+
+    let email = EmailBuilder::new()
+        .to(address)
+        .from((config.smtp_from.clone(), "Bitwarden-rs"))
+        .subject(subject)
+        .header(("Content-Type", "text/html"))
         .body(body)
         .build()
         .map_err(|e| e.to_string())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,7 @@ pub struct Config {
     local_icon_extractor: bool,
     signups_allowed: bool,
     invitations_allowed: bool,
+    email_invitations: bool,
     server_admin_email: Option<String>,
     password_iterations: i32,
     show_password_hint: bool,
@@ -321,6 +322,7 @@ impl Config {
             signups_allowed: get_env_or("SIGNUPS_ALLOWED", true),
             server_admin_email: get_env("SERVER_ADMIN_EMAIL"),
             invitations_allowed: get_env_or("INVITATIONS_ALLOWED", true),
+            email_invitations: get_env_or("EMAIL_INVITATIONS", false),
             password_iterations: get_env_or("PASSWORD_ITERATIONS", 100_000),
             show_password_hint: get_env_or("SHOW_PASSWORD_HINT", true),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,6 @@ pub struct Config {
     local_icon_extractor: bool,
     signups_allowed: bool,
     invitations_allowed: bool,
-    email_invitations: bool,
     server_admin_email: Option<String>,
     password_iterations: i32,
     show_password_hint: bool,
@@ -322,7 +321,6 @@ impl Config {
             signups_allowed: get_env_or("SIGNUPS_ALLOWED", true),
             server_admin_email: get_env("SERVER_ADMIN_EMAIL"),
             invitations_allowed: get_env_or("INVITATIONS_ALLOWED", true),
-            email_invitations: get_env_or("EMAIL_INVITATIONS", false),
             password_iterations: get_env_or("PASSWORD_ITERATIONS", 100_000),
             show_password_hint: get_env_or("SHOW_PASSWORD_HINT", true),
 


### PR DESCRIPTION
This PR adds support for emailing invite tokens to users who are invited to organizations. `EMAIL_INVITATIONS` has been added as a config option that, when enabled, will cause the /invite endpoint to generate a JWT which is valid for 5 days and email the user a link. When the user clicks the link, their UserOrganization status is set to "Accepted", which is what happened automatically before. The previous behavior is unchanged when `EMAIL_INVITATIONS` is not explicitly enabled.

Note the TODO in src/api/core/organizations.rs:511--currently, when the user clicks the invite link, they are just presented with a blank page. I couldn't figure out how to get redirection working in rocket but ideally they would be automatically redirected to the registration page with their email address pre-filled (ie something like `rocket::response::Redirect::to(format!("/#/register?email={}", invite_claims.email))`.

I think a good next step after getting the redirect working would be to email the user who sent the invitation to let them know it has been accepted, and it would be trivial to add to the new `#[get("/organizations/<org_id>/users/<org_user_id>/accept?<token>")]` endpoint added in this PR. 