### PR TITLE
Fix email invitations for existing users and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,15 @@ docker run -d --name bitwarden \
 
 When `SMTP_SSL` is set to `true`(this is the default), only TLSv1.1 and TLSv1.2 protocols will be accepted and `SMTP_PORT` will default to `587`. If set to `false`, `SMTP_PORT` will default to `25` and the connection won't be encrypted. This can be very insecure, use this setting only if you know what you're doing.
 
+Note that if SMTP and invitations are enabled, invitations will be sent to new users via email. You must set the `DOMAIN` configuration option with the base URL of your bitwarden_rs instance for the invite link to be generated correctly:
+
+```sh
+docker run -d --name bitwarden \
+...
+-e DOMAIN=https://vault.example.com
+...
+```
+
 ### Password hint display
 
 Usually, password hints are sent by email. But as bitwarden_rs is made with small or personal deployment in mind, hints are also available from the password hint page, so you don't have to configure an email service. If you want to disable this feature, you can use the `SHOW_PASSWORD_HINT` variable:

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ docker run -d --name bitwarden \
 ...
 ```
 
+User invitation links are valid for 5 days, after which a new invitation will need to be sent.
+
 ### Password hint display
 
 Usually, password hints are sent by email. But as bitwarden_rs is made with small or personal deployment in mind, hints are also available from the password hint page, so you don't have to configure an email service. If you want to disable this feature, you can use the `SHOW_PASSWORD_HINT` variable:

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -532,20 +532,17 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
 
     match User::find_by_mail(&claims.email, &conn) {
         Some(_) => {
-            if Invitation::take(&claims.email, &conn) {
-                if claims.user_org_id.is_some() {
-                    // If this isn't the virtual_org, mark userorg as accepted
-                    let mut user_org = match UserOrganization::find_by_uuid_and_org(&claims.user_org_id.unwrap(), &claims.org_id, &conn) {
-                        Some(user_org) => user_org,
-                        None => err!("Error accepting the invitation") 
-                    };
-                    user_org.status = UserOrgStatus::Accepted as i32;
-                    if user_org.save(&conn).is_err() {
-                        err!("Failed to accept user to organization")
-                    }
+            Invitation::take(&claims.email, &conn);
+            if claims.user_org_id.is_some() {
+                // If this isn't the virtual_org, mark userorg as accepted
+                let mut user_org = match UserOrganization::find_by_uuid_and_org(&claims.user_org_id.unwrap(), &claims.org_id, &conn) {
+                    Some(user_org) => user_org,
+                    None => err!("Error accepting the invitation") 
+                };
+                user_org.status = UserOrgStatus::Accepted as i32;
+                if user_org.save(&conn).is_err() {
+                    err!("Failed to accept user to organization")
                 }
-            } else {
-                err!("Invitation for user not found")
             }
         },
         None => {


### PR DESCRIPTION
This PR updates the invitation /accept logic to rely on JWT validation for inviting existing users to new organizations. Previously, the invitations SQLite table was used, which resulted in a bug when an existing user was invited to join an organization because no invitation was created. 

I've also updated the README to document the new functionality surrounding email invitations and how it's necessary to set the `DOMAIN` configuration option so that links are generated correctly.