### PR TITLE
Change logging timestamp format so fail2ban can parse it

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Though this is unlikely to be required in small deployment, you can fine-tune so
 
 As of release 1.5.0, bitwarden_rs supports logging to file. See [Logging](#logging) above for information on how to set this up.
 
-#### Logging Failed Login Attempts to Syslog
+#### Logging Failed Login Attempts
 
 After specifying the log file location, failed login attempts will appear in the logs in the following format:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn init_logging() -> Result<(), fern::InitError> {
     .format(|out, message, record| {
         out.finish(format_args!(
             "{}[{}][{}] {}",
-            chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+            chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
             record.target(),
             record.level(),
             message


### PR DESCRIPTION
This PR makes a simple change to the timestamp format in the bitwarden logs so that fail2ban can parse it and take appropriate actions. I've also updated the fail2ban documentation to reflect these changes.