### PR TITLE
Send email notifications when invitations are accepted/confirmed

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use crate::api::{JsonResult, JsonUpcase};
 use crate::CONFIG;
 
-use crate::auth::{encode_jwt, generate_invite_claims};
 use crate::mail;
 use crate::db::models::*;
 use crate::db::DbConn;
@@ -48,17 +47,8 @@ fn invite_user(data: JsonUpcase<InviteData>, _token: AdminToken, conn: DbConn) -
     if let Some(ref mail_config) = CONFIG.mail {
         let mut user = User::new(email);
         user.save(&conn)?;
-        let org_id = String::from("00000000-0000-0000-0000-000000000000");
-        let claims = generate_invite_claims(
-            user.uuid.to_string(),
-            user.email.clone(),
-            org_id.clone(),
-            None,
-            None,
-        );
         let org_name = "bitwarden_rs";
-        let invite_token = encode_jwt(&claims);
-        mail::send_invite(&user.email, &org_id, &user.uuid, &invite_token, &org_name, mail_config)?;
+        mail::send_invite(&user.email, &user.uuid, None, None, &org_name, None, mail_config)?;
     }
 
     Ok(Json(json!({})))

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -609,9 +609,9 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
                 Some(org) => org.name,
                 None => String::from("bitwarden_rs"),
         };
-        if claims.invited_by_email.is_some() {
+        if let Some(invited_by_email) = &claims.invited_by_email {
             // User was invited to an organization, so they must be confirmed manually after acceptance
-            mail::send_invite_accepted(&claims.email, &claims.invited_by_email.unwrap(), &org_name, mail_config)?;
+            mail::send_invite_accepted(&claims.email, invited_by_email, &org_name, mail_config)?;
         } else {
             // User was invited from /admin, so they are automatically confirmed
             mail::send_invite_confirmed(&claims.email, &org_name, mail_config)?;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,7 +2,7 @@
 // JWT Handling
 //
 use crate::util::read_file;
-use chrono::Duration;
+use chrono::{Duration, Utc};
 
 use jsonwebtoken::{self, Algorithm, Header};
 use serde::ser::Serialize;
@@ -118,7 +118,26 @@ pub struct InviteJWTClaims {
     pub email: String,
     pub org_id: String,
     pub user_org_id: Option<String>,
-    pub inviter_email: String,
+    pub invited_by_email: Option<String>,
+}
+
+pub fn generate_invite_claims(uuid: String, 
+                          email: String, 
+                          org_id: String, 
+                          org_user_id: Option<String>, 
+                          invited_by_email: Option<String>,
+) -> InviteJWTClaims {
+    let time_now = Utc::now().naive_utc();
+    InviteJWTClaims {
+        nbf: time_now.timestamp(),
+        exp: (time_now + Duration::days(5)).timestamp(),
+        iss: JWT_ISSUER.to_string(),
+        sub: uuid.clone(),
+        email: email.clone(),
+        org_id: org_id.clone(),
+        user_org_id: org_user_id.clone(),
+        invited_by_email: invited_by_email.clone(),
+    }
 }
 
 //

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -116,14 +116,14 @@ pub struct InviteJWTClaims {
     pub sub: String,
 
     pub email: String,
-    pub org_id: String,
+    pub org_id: Option<String>,
     pub user_org_id: Option<String>,
     pub invited_by_email: Option<String>,
 }
 
 pub fn generate_invite_claims(uuid: String, 
                           email: String, 
-                          org_id: String, 
+                          org_id: Option<String>, 
                           org_user_id: Option<String>, 
                           invited_by_email: Option<String>,
 ) -> InviteJWTClaims {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -118,6 +118,7 @@ pub struct InviteJWTClaims {
     pub email: String,
     pub org_id: String,
     pub user_org_id: Option<String>,
+    pub inviter_email: String,
 }
 
 //

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -5,6 +5,7 @@ use lettre_email::EmailBuilder;
 use native_tls::{Protocol, TlsConnector};
 
 use crate::MailConfig;
+use crate::CONFIG;
 
 use crate::api::EmptyResult;
 use crate::error::Error;
@@ -52,21 +53,66 @@ pub fn send_password_hint(address: &str, hint: Option<String>, config: &MailConf
         )
     };
 
-    let email = EmailBuilder::new()
-        .to(address)
-        .from((config.smtp_from.clone(), "Bitwarden-rs"))
-        .subject(subject)
-        .body(body)
-        .build()
-        .map_err(|e| Error::new("Error building hint email", e.to_string()))?;
-
-    mailer(config)
-        .send(email.into())
-        .map_err(|e| Error::new("Error sending hint email", e.to_string()))
-        .and(Ok(()))
+    send_email(&address, &subject, &body, &config)
 }
 
-pub fn send_email(address: &str, subject: &str, body: &str, config: &MailConfig) -> EmptyResult {
+pub fn send_invite(
+    address: &str,
+    org_id: &str,
+    org_user_id: &str,
+    token: &str,
+    org_name: &str,
+    config: &MailConfig,
+) -> EmptyResult {
+    let (subject, body) = {
+        (format!("Join {}", &org_name),
+        format!(
+            "<html>
+             <p>You have been invited to join the <b>{}</b> organization.<br><br>
+             <a href=\"{}/#/accept-organization/?organizationId={}&organizationUserId={}&email={}&organizationName={}&token={}\">Click here to join</a></p>
+             <p>If you do not wish to join this organization, you can safely ignore this email.</p>
+             </html>",
+            org_name, CONFIG.domain, org_id, org_user_id, address, org_name, token
+        ))
+    };
+
+    send_email(&address, &subject, &body, &config)
+}
+
+pub fn send_invite_accepted(
+    new_user_email: &str,
+    address: &str,
+    org_name: &str,
+    config: &MailConfig,
+) -> EmptyResult {
+    let (subject, body) = {
+        ("Invitation accepted",
+        format!(
+            "<html>
+             <p>Your invitation to <b>{}</b> to join <b>{}</b> was accepted. Please log in to the bitwarden_rs server and confirm them from the organization management page.</p>
+             </html>", new_user_email, org_name))
+    };
+
+    send_email(&address, &subject, &body, &config)
+}
+
+pub fn send_invite_confirmed(
+    address: &str,
+    org_name: &str,
+    config: &MailConfig,
+) -> EmptyResult {
+    let (subject, body) = {
+        (format!("Invitation to {} confirmed", org_name),
+        format!(
+            "<html>
+             <p>Your invitation to join <b>{}</b> was accepted. It will now appear under the Organizations the next time you log into the web vault.</p>
+             </html>", org_name))
+    };
+
+    send_email(&address, &subject, &body, &config)
+}
+
+fn send_email(address: &str, subject: &str, body: &str, config: &MailConfig) -> EmptyResult {
     let email = EmailBuilder::new()
     .to(address)
     .from((config.smtp_from.clone(), "Bitwarden-rs"))

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -5,7 +5,6 @@ use lettre_email::EmailBuilder;
 use native_tls::{Protocol, TlsConnector};
 
 use crate::MailConfig;
-use crate::CONFIG;
 
 use crate::api::EmptyResult;
 use crate::error::Error;
@@ -67,37 +66,18 @@ pub fn send_password_hint(address: &str, hint: Option<String>, config: &MailConf
         .and(Ok(()))
 }
 
-pub fn send_invite(
-    address: &str,
-    org_id: &str,
-    org_user_id: &str,
-    token: &str,
-    org_name: &str,
-    config: &MailConfig,
-) -> EmptyResult {
-    let (subject, body) = {
-        (format!("Join {}", &org_name),
-        format!(
-            "<html>
-             <p>You have been invited to join the <b>{}</b> organization.<br><br>
-             <a href=\"{}/#/accept-organization/?organizationId={}&organizationUserId={}&email={}&organizationName={}&token={}\">Click here to join</a></p>
-             <p>If you do not wish to join this organization, you can safely ignore this email.</p>
-             </html>",
-            org_name, CONFIG.domain, org_id, org_user_id, address, org_name, token
-        ))
-    };
-
+pub fn send_email(address: &str, subject: &str, body: &str, config: &MailConfig) -> EmptyResult {
     let email = EmailBuilder::new()
-        .to(address)
-        .from((config.smtp_from.clone(), "Bitwarden-rs"))
-        .subject(subject)
-        .header(("Content-Type", "text/html"))
-        .body(body)
-        .build()
-        .map_err(|e| Error::new("Error building invite email", e.to_string()))?;
+    .to(address)
+    .from((config.smtp_from.clone(), "Bitwarden-rs"))
+    .subject(subject)
+    .header(("Content-Type", "text/html"))
+    .body(body)
+    .build()
+    .map_err(|e| Error::new("Error building email", e.to_string()))?;
 
-    mailer(config)
-        .send(email.into())
-        .map_err(|e| Error::new("Error sending invite email", e.to_string()))
-        .and(Ok(()))
+mailer(config)
+    .send(email.into())
+    .map_err(|e| Error::new("Error sending email", e.to_string()))
+    .and(Ok(()))
 }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -6,7 +6,7 @@ use native_tls::{Protocol, TlsConnector};
 
 use crate::MailConfig;
 use crate::CONFIG;
-
+use crate::auth::{generate_invite_claims, encode_jwt};
 use crate::api::EmptyResult;
 use crate::error::Error;
 
@@ -58,12 +58,21 @@ pub fn send_password_hint(address: &str, hint: Option<String>, config: &MailConf
 
 pub fn send_invite(
     address: &str,
-    org_id: &str,
-    org_user_id: &str,
-    token: &str,
+    uuid: &str,
+    org_id: Option<String>,
+    org_user_id: Option<String>,
     org_name: &str,
+    invited_by_email: Option<String>,
     config: &MailConfig,
 ) -> EmptyResult {
+    let claims = generate_invite_claims(
+                uuid.to_string(),
+                String::from(address),
+                org_id.clone(),
+                org_user_id.clone(),
+                invited_by_email.clone(),
+            );
+    let invite_token = encode_jwt(&claims);
     let (subject, body) = {
         (format!("Join {}", &org_name),
         format!(
@@ -72,7 +81,7 @@ pub fn send_invite(
              <a href=\"{}/#/accept-organization/?organizationId={}&organizationUserId={}&email={}&organizationName={}&token={}\">Click here to join</a></p>
              <p>If you do not wish to join this organization, you can safely ignore this email.</p>
              </html>",
-            org_name, CONFIG.domain, org_id, org_user_id, address, org_name, token
+            org_name, CONFIG.domain, org_id.unwrap_or("_".to_string()), org_user_id.unwrap_or("_".to_string()), address, org_name, invite_token
         ))
     };
 

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -89,8 +89,8 @@ pub fn send_invite_accepted(
         ("Invitation accepted",
         format!(
             "<html>
-             <p>Your invitation to <b>{}</b> to join <b>{}</b> was accepted. Please log in to the bitwarden_rs server and confirm them from the organization management page.</p>
-             </html>", new_user_email, org_name))
+             <p>Your invitation for <b>{}</b> to join <b>{}</b> was accepted. Please <a href=\"{}\">log in</a> to the bitwarden_rs server and confirm them from the organization management page.</p>
+             </html>", new_user_email, org_name, CONFIG.domain))
     };
 
     send_email(&address, &subject, &body, &config)
@@ -105,8 +105,8 @@ pub fn send_invite_confirmed(
         (format!("Invitation to {} confirmed", org_name),
         format!(
             "<html>
-             <p>Your invitation to join <b>{}</b> was accepted. It will now appear under the Organizations the next time you log into the web vault.</p>
-             </html>", org_name))
+             <p>Your invitation to join <b>{}</b> was confirmed. It will now appear under the Organizations the next time you <a href=\"{}\">log in</a> to the web vault.</p>
+             </html>", org_name, CONFIG.domain))
     };
 
     send_email(&address, &subject, &body, &config)
@@ -122,8 +122,8 @@ fn send_email(address: &str, subject: &str, body: &str, config: &MailConfig) -> 
     .build()
     .map_err(|e| Error::new("Error building email", e.to_string()))?;
 
-mailer(config)
-    .send(email.into())
-    .map_err(|e| Error::new("Error sending email", e.to_string()))
-    .and(Ok(()))
+    mailer(config)
+        .send(email.into())
+        .map_err(|e| Error::new("Error sending email", e.to_string()))
+        .and(Ok(()))
 }


### PR DESCRIPTION
This PR sends email notifications to users when their invitee accepts an invitation so they know when to confirm them. It also sends an email to the invitee when they are confirmed, which is the behavior indicated by the web vault when they call the /accept endpoint.

Additionally, I've replaced the specific `send_invite` function with a generic email sending function. This requires the subject and body to be formatted by the caller instead of the callee, which I think offers some flexibility for sending many different types of email, but I am open to discussion on whether we want to keep this approach. 