### PR TITLE
Fix sharing the item to organization.

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -221,7 +221,7 @@ pub fn update_cipher_from_data(
     nt: &Notify,
     ut: UpdateType,
 ) -> EmptyResult {
-    if cipher.organization_uuid != data.OrganizationId {
+    if cipher.organization_uuid.is_some() && cipher.organization_uuid != data.OrganizationId {
         err!("Organization mismatch. Please resync the client before updating the cipher")
     }
 


### PR DESCRIPTION
Simple fix for issue in #341 - we didn't handle the case when the key is just being shared and hence the update won't have matching org IDs. 