### PR TITLE
only use dotenv in debug builds, not in release builds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,9 @@ impl Config {
 
     fn load() -> Self {
         use crate::util::{get_env, get_env_or};
-        dotenv::dotenv().ok();
+        #[cfg(debug_assertions)] {
+            dotenv::dotenv().ok();
+        }
 
         let df = get_env_or("DATA_FOLDER", "data".to_string());
         let key = get_env_or("RSA_KEY_FILENAME", format!("{}/{}", &df, "rsa_key"));


### PR DESCRIPTION
dotenv will look for .env files in the current and all parent
directories. this is potentionaly dangerous in production use.

make it dependent on --debug (the default) builds