### PR TITLE
Allow the Admin token to be disabled in the advanced menu

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -69,6 +69,7 @@
 ## One option is to use 'openssl rand -base64 48'
 ## If not set, the admin panel is disabled
 # ADMIN_TOKEN=Vy2VyYTTsKPv8W5aEOWUbB/Bt3DEKePbHmI4m9VcemUMS2rEviDowNAFqYi1xjmp
+# DISABLE_ADMIN_TOKEN=false
 
 ## Invitations org admins to invite users, even when signups are disabled
 # INVITATIONS_ALLOWED=true

--- a/src/config.rs
+++ b/src/config.rs
@@ -256,6 +256,9 @@ make_config! {
 
         /// Enable DB WAL |> Turning this off might lead to worse performance, but might help if using bitwarden_rs on some exotic filesystems, that do not support WAL. Please make sure you read project wiki on the topic before changing this setting.
         enable_db_wal:          bool,   false,  def,    true;
+
+        /// Disable Admin Token (Know the risks!) |> Disables the Admin Token for the admin page so you may use your own auth in-front
+        disable_admin_token:    bool,   true,   def,    false;
     },
 
     /// Yubikey settings


### PR DESCRIPTION
Adding this option so the /admin endpoint can be secured with an auth of your choosing. 