### PR TITLE
Making a symlink is no longer necessary

### DIFF
--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -78,7 +78,6 @@ RUN apt-get update && apt-get install -y\
     ca-certificates\
     libmariadbclient-dev\
     --no-install-recommends\
- && ln -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3\
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data


### PR DESCRIPTION
armv6 builds have been recently failing, because the `/lib/ld-linux.so.3` file seems to be already present in the latest `balenalib/rpi-debian:stretch` image. This removes the symlink.