### PR TITLE
Fix #468 - Percent-encode the email address in invite link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oath 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quoted_printable 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,9 @@ handlebars = "1.1.0"
 soup = "0.4.1"
 regex = "1.1.7"
 
+# URL encoding library
+percent-encoding = "1.0.1"
+
 [patch.crates-io]
 # Add support for Timestamp type
 rmp = { git = 'https://github.com/dani-garcia/msgpack-rust' }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -4,6 +4,7 @@ use lettre::{ClientSecurity, ClientTlsParameters, SmtpClient, SmtpTransport, Tra
 use lettre_email::{EmailBuilder, MimeMultipartType, PartBuilder};
 use native_tls::{Protocol, TlsConnector};
 use quoted_printable::encode_to_str;
+use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 
 use crate::api::EmptyResult;
 use crate::auth::{encode_jwt, generate_invite_claims};
@@ -101,7 +102,7 @@ pub fn send_invite(
             "url": CONFIG.domain(),
             "org_id": org_id.unwrap_or_else(|| "_".to_string()),
             "org_user_id": org_user_id.unwrap_or_else(|| "_".to_string()),
-            "email": address,
+            "email": percent_encode(address.as_bytes(), DEFAULT_ENCODE_SET).to_string().replace("+", "%2b"),
             "org_name": org_name,
             "token": invite_token,
         }),


### PR DESCRIPTION
URL-encode the email address when generating the invite link so that "+"s and other special characters get correctly filled-in by the vault instead of being interpreted as a space.