### PR TITLE
Add config option to require new device emails

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -108,6 +108,10 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: ClientIp) -> JsonResult 
     if CONFIG.mail_enabled() && new_device {
         if let Err(e) = mail::send_new_device_logged_in(&user.email, &ip.ip.to_string(), &device.updated_at, &device.name) {
             error!("Error sending new device email: {:#?}", e);
+
+            if CONFIG.require_device_email() {
+                err!("Could not send login notification email. Please contact your administrator.")
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,6 +269,10 @@ make_config! {
         /// Note that the checkbox would still be present, but ignored.
         disable_2fa_remember:   bool,   true,   def,    false;
 
+        /// Require new device emails |> When a user logs in an email is required to be sent.
+        /// If sending the email fails the login attempt will fail.
+        require_device_email:   bool,   true,   def,     false;
+
         /// Reload templates (Dev) |> When this is set to true, the templates get reloaded with every request.
         /// ONLY use this during development, as it can slow down the server
         reload_templates:       bool,   true,   def,    false;


### PR DESCRIPTION
I've added a config option under Advanced.