### PR TITLE
Allow explicitly defined smtp auth mechansim

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -149,3 +149,4 @@
 # SMTP_SSL=true
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
+# SMTP_AUTH_MECHANISM="Plain"

--- a/src/config.rs
+++ b/src/config.rs
@@ -345,6 +345,8 @@ make_config! {
         smtp_username:          String, true,   option;
         /// Password
         smtp_password:          Pass,   true,   option;
+        /// Json form auth mechanism |> Defaults for ssl is "Plain" and "Login" and nothing for non-ssl connections. Possible values: ["Plain", "Login", "Xoauth2"]
+        smtp_auth_mechanism:    String, true,   option;
     },
 }
 

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -42,7 +42,7 @@ fn mailer() -> SmtpTransport {
 
     let smtp_client = match &CONFIG.smtp_auth_mechanism() {
         Some(auth_mechanism_json) => {
-            let auth_mechanism = serde_json::from_str::<SmtpAuthMechanism>(&auth_mechanism_json.clone());
+            let auth_mechanism = serde_json::from_str::<SmtpAuthMechanism>(&auth_mechanism_json);
             match auth_mechanism {
                 Ok(auth_mechanism) => smtp_client.authentication_mechanism(auth_mechanism),
                 Err(_) => panic!("Failure to parse mechanism. Is it proper Json? Eg. `\"Plain\"` not `Plain`"),


### PR DESCRIPTION
This allows using `Xoauth2` or forcing an auth mechanism over an unencrypted connection.