### PR TITLE
Fix #603 and  remove mysql from sqlite image

### DIFF
--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
+    curl \
     libmariadbclient-dev \
  && rm -rf /var/lib/apt/lists/*
 
@@ -99,7 +100,7 @@ COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
-    libmariadbclient-dev \
+    curl \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
@@ -99,7 +99,7 @@ COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
+    curl \
     libmariadbclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -96,7 +97,7 @@ COPY --from=build app/target/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -63,6 +63,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN apk add --no-cache \
         openssl \
         mariadb-connector-c \
+        curl \
         ca-certificates
 
 RUN mkdir /data
@@ -78,7 +79,7 @@ COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
-    libmariadbclient-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
@@ -96,7 +96,7 @@ COPY --from=build app/target/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -62,7 +62,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \
-        mariadb-connector-c \
+        curl \
         ca-certificates
 
 RUN mkdir /data
@@ -78,7 +78,7 @@ COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 
 # Configures the startup!

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
+    curl \
     libmariadbclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -99,7 +100,7 @@ COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
-    libmariadbclient-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
@@ -99,7 +99,7 @@ COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
+    curl \
     libmariadbclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -100,7 +101,7 @@ COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
-    libmariadbclient-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
@@ -99,7 +99,7 @@ COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs
 
 COPY docker/healthcheck.sh ./healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=1s CMD bash healthcheck.sh || exit 1
+HEALTHCHECK --interval=10s --timeout=1s CMD sh healthcheck.sh || exit 1
 
 # Configures the startup!
 CMD ["./bitwarden_rs"]


### PR DESCRIPTION
This changes the healthcheck to use `sh` instead of bash, that is absent
from some image versions. (like alpine)

It also removes `*mariadb*` packages from runtime image of sqlite images
as these shouldn't be required.