### PR TITLE
Add sqlite binary into the docker images

### DIFF
--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    sqlite3 \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    sqlite3 \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -64,6 +64,7 @@ RUN apk add --no-cache \
         openssl \
         postgresql-libs \
         curl \
+        sqlite \
         ca-certificates
 
 RUN mkdir /data

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -63,6 +63,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN apk add --no-cache \
         openssl \
         curl \
+        sqlite \
         ca-certificates
 
 RUN mkdir /data

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -37,11 +37,7 @@ pub fn routes() -> Vec<Route> {
 }
 
 lazy_static! {
-    static ref CAN_BACKUP: bool = cfg!(feature = "sqlite") && 
-    ( 
-        Command::new("sqlite").arg("-version").status().is_ok() ||
-        Command::new("sqlite3").arg("-version").status().is_ok()
-    );
+    static ref CAN_BACKUP: bool = cfg!(feature = "sqlite") && Command::new("sqlite3").arg("-version").status().is_ok();
 }
 
 #[get("/")]

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -37,7 +37,11 @@ pub fn routes() -> Vec<Route> {
 }
 
 lazy_static! {
-    static ref CAN_BACKUP: bool = cfg!(feature = "sqlite") && Command::new("sqlite").arg("-version").status().is_ok();
+    static ref CAN_BACKUP: bool = cfg!(feature = "sqlite") && 
+    ( 
+        Command::new("sqlite").arg("-version").status().is_ok() ||
+        Command::new("sqlite3").arg("-version").status().is_ok()
+    );
 }
 
 #[get("/")]


### PR DESCRIPTION
This is done to enable backup functionality in the admin interface while
we're waiting for the libsqlite-sys 0.17 to bubble up in the upstream
dependencies. Then we can start using `VACUUM INTO`

This also extends the check for the sqlite binary to also try `sqlite3`
as this is the name of the binary in baseimage distributions we use.