### PR TITLE
Change CORS headers

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -42,6 +42,13 @@ impl CORS {
             _ => "".to_string(),
         }
     }
+
+    fn valid_url(url: String) -> String {
+        match url.as_ref() {
+            "file://" => "*".to_string(),
+            _ => url,
+        }
+    }
 }
 
 impl Fairing for CORS {
@@ -56,21 +63,17 @@ impl Fairing for CORS {
         let req_headers = request.headers();
 
         // We need to explicitly get the Origin header for Access-Control-Allow-Origin
-        let req_allow_origin = CORS::get_header(&req_headers, "Origin");
+        let req_allow_origin = CORS::valid_url(CORS::get_header(&req_headers, "Origin"));
 
-        let req_allow_headers = CORS::get_header(&req_headers, "Access-Control-Request-Headers");
+        response.set_header(Header::new("Access-Control-Allow-Origin", req_allow_origin));
 
-        let req_allow_method = CORS::get_header(&req_headers,"Access-Control-Request-Method");
+        if request.method() == Method::Options {
+            let req_allow_headers = CORS::get_header(&req_headers, "Access-Control-Request-Headers");
+            let req_allow_method = CORS::get_header(&req_headers,"Access-Control-Request-Method");
 
-        if request.method() == Method::Options || response.content_type() == Some(ContentType::JSON) {
-            // Requests with credentials need explicit values since they do not allow wildcards.
-            response.set_header(Header::new("Access-Control-Allow-Origin", req_allow_origin));
             response.set_header(Header::new("Access-Control-Allow-Methods", req_allow_method));
             response.set_header(Header::new("Access-Control-Allow-Headers", req_allow_headers));
             response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
-        }
-
-        if request.method() == Method::Options {
             response.set_status(Status::Ok);
             response.set_header(ContentType::Plain);
             response.set_sized_body(Cursor::new(""));


### PR DESCRIPTION
All CORS header used to be added always even when that was not necessary.
Changed to only add Allow-Origin to all requests and move the others to preflight OPTIONS request.

Extension sends the request with `file://` Origin. This seems to cause problems.
If Origin is `file://` change it to the wildcard.

This seems to correspond with the responses from the official API.

Before merging
- [x] Confirmation of fix from other Safari 13 extension user

Fixes #629