### PR TITLE
Fix 2FA email not sending

### DIFF
--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -55,17 +55,18 @@ fn send_email_login(data: JsonUpcase<SendEmailLoginData>, conn: DbConn) -> Empty
         err!("Email 2FA is disabled")
     }
 
-    let type_ = TwoFactorType::Email as i32;
-    let mut twofactor = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn)?;
-
-    prepare_send_token(&mut twofactor, &conn)?;
+    send_token(&user.uuid, &conn)?;
 
     Ok(())
 }
 
 /// Generate the token, save the data for later verification and send email to user
-pub fn prepare_send_token(twofactor: &mut TwoFactor, conn: &DbConn) -> EmptyResult {
+pub fn send_token(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+    let type_ = TwoFactorType::Email as i32;
+    let mut twofactor = TwoFactor::find_by_user_and_type(user_uuid, type_, &conn)?;
+
     let generated_token = generate_token(CONFIG.email_token_size())?;
+
     let mut twofactor_data = EmailTokenData::from_json(&twofactor.data)?;
     twofactor_data.set_token(generated_token);
     twofactor.data = twofactor_data.to_json();

--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -58,6 +58,13 @@ fn send_email_login(data: JsonUpcase<SendEmailLoginData>, conn: DbConn) -> Empty
     let type_ = TwoFactorType::Email as i32;
     let mut twofactor = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn)?;
 
+    prepare_send_token(&mut twofactor, &conn)?;
+
+    Ok(())
+}
+
+/// Generate the token, save the data for later verification and send email to user
+pub fn prepare_send_token(twofactor: &mut TwoFactor, conn: &DbConn) -> EmptyResult {
     let generated_token = generate_token(CONFIG.email_token_size())?;
     let mut twofactor_data = EmailTokenData::from_json(&twofactor.data)?;
     twofactor_data.set_token(generated_token);

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -293,13 +293,19 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             }
 
             Some(tf_type @ TwoFactorType::Email) => {
-                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, &conn) {
+                use crate::api::core::two_factor as _tf;
+
+                let mut twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, &conn) {
                     Some(tf) => tf,
                     None => err!("No twofactor email registered"),
                 };
 
-                let email_data = EmailTokenData::from_json(&twofactor.data)?;
+                // Send email immediately if email is the only 2FA option
+                if providers.len() == 1 {
+                    _tf::email::prepare_send_token(&mut twofactor, &conn)?
+                }
 
+                let email_data = EmailTokenData::from_json(&twofactor.data)?;
                 result["TwoFactorProviders2"][provider.to_string()] = json!({
                     "Email": email::obscure_email(&email_data.email),
                 })

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -295,14 +295,14 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             Some(tf_type @ TwoFactorType::Email) => {
                 use crate::api::core::two_factor as _tf;
 
-                let mut twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, &conn) {
+                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, &conn) {
                     Some(tf) => tf,
                     None => err!("No twofactor email registered"),
                 };
 
                 // Send email immediately if email is the only 2FA option
                 if providers.len() == 1 {
-                    _tf::email::prepare_send_token(&mut twofactor, &conn)?
+                    _tf::email::send_token(&user_uuid, &conn)?
                 }
 
                 let email_data = EmailTokenData::from_json(&twofactor.data)?;


### PR DESCRIPTION
The 2FA email was not sent when email was the only 2FA method available.

Moved generate token, save token and send email logic to separate function.
Called from the separate `send-email-login` API call and when Email is the only 2FA provider in the `invalid grant` JsonError response.

Fixes #611 