### PR TITLE
Remove unsupported WS transport

### DIFF
--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -26,7 +26,7 @@ fn negotiate(_headers: Headers, _conn: DbConn) -> JsonResult {
     let mut available_transports: Vec<JsonValue> = Vec::new();
 
     if CONFIG.websocket_enabled() {
-        available_transports.push(json!({"transport":"WebSockets", "transferFormats":["Text","Binary"]}));
+        available_transports.push(json!({"transport":"WebSockets", "transferFormats":["Text"]}));
     }
 
     // TODO: Implement transports


### PR DESCRIPTION
This stops the spamming:
```
[2019-10-16 13:06:27][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:06:42][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:06:57][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:07:12][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:07:27][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:07:42][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.                                           
[2019-10-16 13:07:57][bitwarden_rs::api::notifications][INFO] Server got message 'Binary Data<length=3>'.   
```

I'm not sure if it is unsupported, nor if it breaks for someone else.
Please treat it as "Works for me".