### PR TITLE
Compile sqlite version by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ publish = false
 build = "build.rs"
 
 [features]
+# By default compile the sqlite version
+# different DB backend can be compiled by running:
+# cargo build --no-default-features --features <mysql|postgresql>
+default = ["sqlite"]
+
 # Empty to keep compatibility, prefer to set USE_SYSLOG=true
 enable_syslog = []
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]

--- a/build.rs
+++ b/build.rs
@@ -2,14 +2,14 @@ use std::process::Command;
 
 fn main() {
     #[cfg(all(feature = "sqlite", feature = "mysql"))]
-    compile_error!("Can't enable both sqlite and mysql at the same time");
+    compile_error!("Can't enable both sqlite and mysql at the same time. To build with mysql support do: cargo build --no-default-features --features mysql");
     #[cfg(all(feature = "sqlite", feature = "postgresql"))]
-    compile_error!("Can't enable both sqlite and postgresql at the same time");
+    compile_error!("Can't enable both sqlite and postgresql at the same time. To build with postgresql support do: cargo build --no-default-features --features postgresql");
     #[cfg(all(feature = "mysql", feature = "postgresql"))]
     compile_error!("Can't enable both mysql and postgresql at the same time");
 
     #[cfg(not(any(feature = "sqlite", feature = "mysql", feature = "postgresql")))]
-    compile_error!("You need to enable one DB backend. To build with previous defaults do: cargo build --features sqlite");
+    compile_error!("You need to enable one DB backend. To build with your preferred backend do: cargo build --no-default-features --features <backend>");
 
     read_git_info().ok();
 }

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -63,7 +63,7 @@ COPY . .
 
 # Build
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu -v
+RUN cargo build --no-default-features --features ${DB} --release --target=aarch64-unknown-linux-gnu -v
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -52,7 +52,7 @@ COPY ./build.rs ./build.rs
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -64,7 +64,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -47,7 +47,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN touch src/main.rs
 
 # Build
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -52,7 +52,7 @@ COPY ./build.rs ./build.rs
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -64,7 +64,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -47,7 +47,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN touch src/main.rs
 
 # Build
-RUN cargo build --features ${DB} --release
+RUN cargo build --no-default-features --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -63,7 +63,7 @@ COPY . .
 
 # Build
 RUN rustup target add arm-unknown-linux-gnueabi
-RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi -v
+RUN cargo build --no-default-features --features ${DB} --release --target=arm-unknown-linux-gnueabi -v
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -64,7 +64,7 @@ COPY . .
 
 # Build
 RUN rustup target add armv7-unknown-linux-gnueabihf
-RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf -v
+RUN cargo build --no-default-features --features ${DB} --release --target=armv7-unknown-linux-gnueabihf -v
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image


### PR DESCRIPTION
This sets the default feature to sqlite, so that it will correctly
compile "out of the box". Users can still choose different backend by
running:

```
cargo build --no-default-features --features <backend>
```