### PR TITLE
Fixed issue #709 creating icon_cache directory.

### DIFF
--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -112,7 +112,7 @@ fn get_icon(domain: &str) -> Vec<u8> {
         }
         Err(e) => {
             error!("Error downloading icon: {:?}", e);
-            let miss_indicator = path.to_owned() + ".miss";
+            let miss_indicator = path + ".miss";
             let empty_icon = Vec::new();
             save_icon(&miss_indicator, &empty_icon);
             FALLBACK_ICON.to_vec()

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -104,6 +104,9 @@ fn get_icon(domain: &str) -> Vec<u8> {
         return FALLBACK_ICON.to_vec();
     }
 
+    // Create icon_cache_folder before fetching
+    create_dir_all(&CONFIG.icon_cache_folder()).expect("Error creating icon cache");
+
     // Get the icon, or fallback in case of error
     match download_icon(&domain) {
         Ok(icon) => {
@@ -395,8 +398,6 @@ fn download_icon(domain: &str) -> Result<Vec<u8>, Error> {
 }
 
 fn save_icon(path: &str, icon: &[u8]) {
-    create_dir_all(&CONFIG.icon_cache_folder()).expect("Error creating icon cache");
-
     if let Ok(mut f) = File::create(path) {
         f.write_all(icon).expect("Error writing icon file");
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ extern crate num_derive;
 use std::{
     path::Path,
     process::{exit, Command},
+    fs::create_dir_all,
 };
 
 #[macro_use]
@@ -51,6 +52,8 @@ fn main() {
     check_rsa_keys();
     check_web_vault();
     migrations::run_migrations();
+
+    create_icon_cache_folder();
 
     launch_rocket();
 }
@@ -129,8 +132,7 @@ fn check_db() {
         let path = Path::new(&url);
 
         if let Some(parent) = path.parent() {
-            use std::fs;
-            if fs::create_dir_all(parent).is_err() {
+            if create_dir_all(parent).is_err() {
                 error!("Error creating database directory");
                 exit(1);
             }
@@ -146,6 +148,11 @@ fn check_db() {
         }
     }
     db::get_connection().expect("Can't connect to DB");
+}
+
+fn create_icon_cache_folder() {
+    // Try to create the icon cache folder, and generate an error if it could not.
+    create_dir_all(&CONFIG.icon_cache_folder()).expect("Error creating icon cache directory");
 }
 
 fn check_rsa_keys() {


### PR DESCRIPTION
When the icon_cache directory doesn't exists yet, and the first icon
catched is a miss this .miss file was not able to be created since the
directory was only created during a valid icon download.