### PR TITLE
Fixed issue/request #705

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -140,6 +140,18 @@
 ## After that, you should be able to follow the rest of the guide linked above,
 ## ignoring the fields that ask for the values that you already configured beforehand.
 
+## Authenticator Settings
+## Disable authenticator time drifted codes to be valid.
+## TOTP codes of the previous and next 30 seconds will be invalid
+## 
+## According to the RFC6238 (https://tools.ietf.org/html/rfc6238),
+## we allow by default the TOTP code which was valid one step back and one in the future.
+## This can however allow attackers to be a bit more lucky with there attempts because there are 3 valid codes.
+## You can disable this, so that only the current TOTP Code is allowed.
+## Keep in mind that when a sever drifts out of time, valid codes could be marked as invalid.
+## In any case, if a code has been used it can not be used again, also codes which predates it will be invalid.
+# AUTHENTICATOR_DISABLE_TIME_DRIFT = false
+
 ## Rocket specific settings, check Rocket documentation to learn more
 # ROCKET_ENV=staging
 # ROCKET_ADDRESS=0.0.0.0 # Enable this to test mobile app

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,10 @@ make_config! {
         /// Note that the checkbox would still be present, but ignored.
         disable_2fa_remember:   bool,   true,   def,    false;
 
+        /// Disable authenticator time drifted codes to be valid |> Enabling this only allows the current TOTP code to be valid
+        /// TOTP codes of the previous and next 30 seconds will be invalid.
+        authenticator_disable_time_drift:     bool,   true,  def,    false;
+
         /// Require new device emails |> When a user logs in an email is required to be sent.
         /// If sending the email fails the login attempt will fail.
         require_device_email:   bool,   true,   def,     false;


### PR DESCRIPTION
Added a config option to disable time drifted totp codes.
Default is false, since this is what the RFC recommends.