### PR TITLE
Added tv.apple.com to global domains

### DIFF
--- a/src/static/global_domains.json
+++ b/src/static/global_domains.json
@@ -39,7 +39,8 @@
     "Type": 1,
     "Domains": [
       "apple.com",
-      "icloud.com"
+      "icloud.com",
+      "tv.apple.com"
     ],
     "Excluded": false
   },


### PR DESCRIPTION
I added https://tv.apple.com/ to the global Apple domains. Its the website used to watch Apple TV+ series.