### PR TITLE
Use Debian base image for all steps of the build process

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -37,10 +37,14 @@ RUN apk add --no-cache --upgrade \
     curl \
     tar
 {% else %}
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -79,6 +83,12 @@ ARG DB=mysql
 # set postgresql backend
 ARG DB=postgresql
 {% endif %}
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -156,7 +156,7 @@ RUN apt-get update && apt-get install -y \
 
 {% endif %}
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -87,6 +87,18 @@ RUN rustup set profile minimal
 ENV USER "root"
 
 {% endif %}
+{% if "aarch64" in target_file or "armv" in target_file %}
+# Install required build libs for {{ package_arch_name }} architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture {{ package_arch_name }} \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev{{ package_arch_prefix }} \
+        libc6-dev{{ package_arch_prefix }}
+
+{% endif -%}
 {% if "aarch64" in target_file %}
 RUN apt-get update \
     && apt-get install -y \
@@ -142,19 +154,6 @@ RUN apt-get update && apt-get install -y \
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin app
 WORKDIR /app
-
-{% if "aarch64" in target_file or "armv" in target_file %}
-# Install required build libs for {{ package_arch_name }} architecture.
-RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
-        /etc/apt/sources.list.d/deb-src.list \
-    && dpkg --add-architecture {{ package_arch_name }} \
-    && apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        libssl-dev{{ package_arch_prefix }} \
-        libc6-dev{{ package_arch_prefix }}
-
-{% endif -%}
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -1,0 +1,276 @@
+# Using multistage build:
+# 	https://docs.docker.com/develop/develop-images/multistage-build/
+# 	https://whitfin.io/speeding-up-rust-docker-builds/
+####################### VAULT BUILD IMAGE  #######################
+{% if "alpine" in target_file %}
+{%   set preferred_base_image = "alpine:3.11" %}
+{%   set package_arch_name = "" %}
+{% elif "amd64" in target_file %}
+{%   set preferred_base_image = "debian:buster-slim" %}
+{%   set package_arch_name = "" %}
+{% elif "aarch64" in target_file %}
+{%   set preferred_base_image = "balenalib/aarch64-debian:buster" %}
+{%   set package_arch_name = "arm64" %}
+{% elif "armv6" in target_file %}
+{%   set preferred_base_image = "balenalib/rpi-debian:buster" %}
+{%   set package_arch_name = "armel" %}
+{% elif "armv7" in target_file %}
+{%   set preferred_base_image = "balenalib/armv7hf-debian:buster" %}
+{%   set package_arch_name = "armhf" %}
+{% endif %}
+{% set package_arch_prefix = ":" + package_arch_name %}
+{% if package_arch_name == "" %}
+{%   set package_arch_prefix = "" %}
+{% endif %}
+FROM {{ preferred_base_image }} as vault
+
+ENV VAULT_VERSION "v2.12.0b"
+
+ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
+
+{% if "alpine" in target_file %}
+RUN apk add --no-cache --upgrade \
+    curl \
+    tar
+{% else %}
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
+{% endif %}
+
+RUN mkdir /web-vault
+WORKDIR /web-vault
+
+{% if "alpine" in target_file %}
+SHELL ["/bin/ash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
+{% else %}
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
+{% endif %}
+
+RUN curl -L $URL | tar xz
+RUN ls
+
+########################## BUILD IMAGE  ##########################
+{% if "alpine" in target_file %}
+# Musl build image for statically compiled binary
+FROM clux/muslrust:nightly-2019-12-19 as build
+{% else %}
+# We need to use the Rust build image, because
+# we need the Rust compiler and Cargo tooling
+FROM rust:1.40 as build
+{% endif %}
+
+{% if "sqlite" in target_file %}
+# set sqlite as default for DB ARG for backward compatibility
+ARG DB=sqlite
+{% elif "mysql" in target_file %}
+# set mysql backend
+ARG DB=mysql
+{% elif "postgresql" in target_file %}
+# set postgresql backend
+ARG DB=postgresql
+{% endif %}
+
+# Don't download rust docs
+RUN rustup set profile minimal
+
+{% if "alpine" in target_file %}
+ENV USER "root"
+
+{% endif %}
+{% if "aarch64" in target_file %}
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-aarch64-linux-gnu \
+    && mkdir -p ~/.cargo \
+    && echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config \
+    && echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
+{% elif "armv6" in target_file %}
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-arm-linux-gnueabi \
+    && mkdir -p ~/.cargo \
+    && echo '[target.arm-unknown-linux-gnueabi]' >> ~/.cargo/config \
+    && echo 'linker = "arm-linux-gnueabi-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
+{% elif "armv6" in target_file %}
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-arm-linux-gnueabihf \
+    && mkdir -p ~/.cargo \
+    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
+{% endif %}
+{% if "mysql" in target_file %}
+# Install MySQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libmariadb-dev{{ package_arch_prefix }} \
+    && rm -rf /var/lib/apt/lists/*
+
+{% elif "postgresql" in target_file %}
+# Install PostgreSQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libpq-dev{{ package_arch_prefix }} \
+    && rm -rf /var/lib/apt/lists/*
+
+{% endif %}
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
+WORKDIR /app
+
+{% if "aarch64" in target_file or "armv" in target_file %}
+# Install required build libs for {{ package_arch_name }} architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture {{ package_arch_name }} \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev{{ package_arch_prefix }} \
+        libc6-dev{{ package_arch_prefix }}
+
+{% endif -%}
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
+{% if "aarch64" in target_file %}
+ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
+ENV CROSS_COMPILE="1"
+ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
+ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
+{% elif "armv6" in target_file %}
+ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
+ENV CROSS_COMPILE="1"
+ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
+ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+{% endif -%}
+
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
+
+# Copies the complete project
+# To avoid copying unneeded files, use .dockerignore
+COPY . .
+
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+{% if "alpine" in target_file %}
+RUN rustup target add x86_64-unknown-linux-musl
+
+{% endif %}
+# Builds again, this time it'll just be
+# your actual source files being built
+{% if "amd64" in target_file %}
+RUN cargo build --features ${DB} --release
+{% elif "aarch64" in target_file %}
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
+{% endif %}
+
+######################## RUNTIME IMAGE  ########################
+# Create a new stage with a minimal image
+# because we already have a binary built
+FROM {{ preferred_base_image }}
+
+ENV ROCKET_ENV "staging"
+ENV ROCKET_PORT=80
+ENV ROCKET_WORKERS=10
+{% if "alpine" in target_file %}
+ENV SSL_CERT_DIR=/etc/ssl/certs
+{% endif %}
+
+{% if "amd64" not in target_file %}
+RUN [ "cross-build-start" ]
+{% endif %}
+
+# Install needed libraries
+{% if "alpine" in target_file %}
+RUN apk add --no-cache \
+        openssl \
+        curl \
+{% if "sqlite" in target_file %}
+        sqlite \
+{% elif "mysql" in target_file %}
+        mariadb-connector-c \
+{% elif "postgresql" in target_file %}
+        postgresql-libs \
+{% endif %}
+        ca-certificates
+{% else %}
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    openssl \
+    ca-certificates \
+    curl \
+{% if "sqlite" in target_file %}
+    sqlite3 \
+{% elif "mysql" in target_file %}
+    libmariadbclient-dev \
+{% elif "postgresql" in target_file %}
+    libpq5 \
+{% endif %}
+    && rm -rf /var/lib/apt/lists/*
+{% endif %}
+
+RUN mkdir /data
+{% if "amd64" not in target_file %}
+
+RUN [ "cross-build-end" ]
+
+{% endif %}
+VOLUME /data
+EXPOSE 80
+EXPOSE 3012
+
+# Copies the files from the context (Rocket.toml file and web-vault)
+# and the binary from the "build" stage to the current stage
+COPY Rocket.toml .
+COPY --from=vault /web-vault ./web-vault
+{% if "alpine" in target_file %}
+COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
+{% elif "aarch64" in target_file %}
+COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
+{% elif "armv6" in target_file %}
+COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
+{% elif "armv7" in target_file %}
+COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs .
+{% else %}
+COPY --from=build app/target/release/bitwarden_rs .
+{% endif %}
+
+COPY docker/healthcheck.sh ./healthcheck.sh
+
+HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+
+# Configures the startup!
+WORKDIR /
+CMD ["/bitwarden_rs"]

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -45,8 +45,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 {% endif %}

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -228,6 +228,8 @@ RUN cargo build --features ${DB} --release
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 {% elif "armv6" in target_file %}
 RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
+{% elif "armv7" in target_file %}
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 {% endif %}
 
 ######################## RUNTIME IMAGE  ########################

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -2,33 +2,37 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
+{% set build_stage_base_image = "rust:1.40" %}
+{% set vault_stage_base_image = build_stage_base_image %}
 {% if "alpine" in target_file %}
-{%   set preferred_base_image = "alpine:3.11" %}
+{%   set build_stage_base_image = "clux/muslrust:nightly-2019-12-19" %}
+{%   set runtime_stage_base_image = "alpine:3.11" %}
+{%   set vault_stage_base_image = runtime_stage_base_image %}
 {%   set package_arch_name = "" %}
 {% elif "amd64" in target_file %}
-{%   set preferred_base_image = "debian:buster-slim" %}
+{%   set runtime_stage_base_image = "debian:buster-slim" %}
 {%   set package_arch_name = "" %}
 {% elif "aarch64" in target_file %}
-{%   set preferred_base_image = "balenalib/aarch64-debian:buster" %}
+{%   set runtime_stage_base_image = "balenalib/aarch64-debian:buster" %}
 {%   set package_arch_name = "arm64" %}
 {% elif "armv6" in target_file %}
-{%   set preferred_base_image = "balenalib/rpi-debian:buster" %}
+{%   set runtime_stage_base_image = "balenalib/rpi-debian:buster" %}
 {%   set package_arch_name = "armel" %}
 {% elif "armv7" in target_file %}
-{%   set preferred_base_image = "balenalib/armv7hf-debian:buster" %}
+{%   set runtime_stage_base_image = "balenalib/armv7hf-debian:buster" %}
 {%   set package_arch_name = "armhf" %}
 {% endif %}
 {% set package_arch_prefix = ":" + package_arch_name %}
 {% if package_arch_name == "" %}
 {%   set package_arch_prefix = "" %}
 {% endif %}
-FROM {{ preferred_base_image }} as vault
+FROM {{ vault_stage_base_image }} as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-{% if "alpine" in target_file %}
+{% if "alpine" in vault_stage_base_image %}
 RUN apk add --no-cache --upgrade \
     curl \
     tar
@@ -47,7 +51,7 @@ RUN apt update -y \
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-{% if "alpine" in target_file %}
+{% if "alpine" in vault_stage_base_image %}
 SHELL ["/bin/ash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 {% else %}
 SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
@@ -57,14 +61,13 @@ RUN curl -L $URL | tar xz
 RUN ls
 
 ########################## BUILD IMAGE  ##########################
-{% if "alpine" in target_file %}
+{% if "musl" in build_stage_base_image %}
 # Musl build image for statically compiled binary
-FROM clux/muslrust:nightly-2019-12-19 as build
 {% else %}
 # We need to use the Rust build image, because
 # we need the Rust compiler and Cargo tooling
-FROM rust:1.40 as build
 {% endif %}
+FROM {{ build_stage_base_image }} as build
 
 {% if "sqlite" in target_file %}
 # set sqlite as default for DB ARG for backward compatibility
@@ -199,12 +202,12 @@ RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM {{ preferred_base_image }}
+FROM {{ runtime_stage_base_image }}
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
-{% if "alpine" in target_file %}
+{% if "alpine" in runtime_stage_base_image %}
 ENV SSL_CERT_DIR=/etc/ssl/certs
 {% endif %}
 
@@ -213,17 +216,17 @@ RUN [ "cross-build-start" ]
 {% endif %}
 
 # Install needed libraries
-{% if "alpine" in target_file %}
+{% if "alpine" in runtime_stage_base_image %}
 RUN apk add --no-cache \
         openssl \
         curl \
-{% if "sqlite" in target_file %}
+{%   if "sqlite" in target_file %}
         sqlite \
-{% elif "mysql" in target_file %}
+{%   elif "mysql" in target_file %}
         mariadb-connector-c \
-{% elif "postgresql" in target_file %}
+{%   elif "postgresql" in target_file %}
         postgresql-libs \
-{% endif %}
+{%   endif %}
         ca-certificates
 {% else %}
 RUN apt-get update && apt-get install -y \
@@ -231,13 +234,13 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
-{% if "sqlite" in target_file %}
+{%   if "sqlite" in target_file %}
     sqlite3 \
-{% elif "mysql" in target_file %}
+{%   elif "mysql" in target_file %}
     libmariadbclient-dev \
-{% elif "postgresql" in target_file %}
+{%   elif "postgresql" in target_file %}
     libpq5 \
-{% endif %}
+{%   endif %}
     && rm -rf /var/lib/apt/lists/*
 {% endif %}
 

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -182,6 +182,9 @@ RUN rustup target add x86_64-unknown-linux-musl
 {% elif "aarch64" in target_file %}
 RUN rustup target add aarch64-unknown-linux-gnu
 
+{% elif "armv6" in target_file %}
+RUN rustup target add arm-unknown-linux-gnueabi
+
 {% endif %}
 # Builds your dependencies and removes the
 # dummy project, except the target folder
@@ -202,6 +205,8 @@ RUN touch src/main.rs
 RUN cargo build --features ${DB} --release
 {% elif "aarch64" in target_file %}
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
+{% elif "armv6" in target_file %}
+RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 {% endif %}
 
 ######################## RUNTIME IMAGE  ########################

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -135,6 +135,18 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
+{% elif "armv7" in target_file %}
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-arm-linux-gnueabihf \
+    && mkdir -p ~/.cargo \
+    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
 {% endif %}
 {% if "mysql" in target_file %}
 # Install MySQL package

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -176,6 +176,13 @@ ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
 {% endif -%}
 
+{% if "alpine" in target_file %}
+RUN rustup target add x86_64-unknown-linux-musl
+
+{% elif "aarch64" in target_file %}
+RUN rustup target add aarch64-unknown-linux-gnu
+
+{% endif %}
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -189,16 +196,11 @@ COPY . .
 # Make sure that we actually build the project
 RUN touch src/main.rs
 
-{% if "alpine" in target_file %}
-RUN rustup target add x86_64-unknown-linux-musl
-
-{% endif %}
 # Builds again, this time it'll just be
 # your actual source files being built
 {% if "amd64" in target_file %}
 RUN cargo build --features ${DB} --release
 {% elif "aarch64" in target_file %}
-RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 {% endif %}
 

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -198,6 +198,11 @@ ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+{% elif "armv7" in target_file %}
+ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
+ENV CROSS_COMPILE="1"
+ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
+ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
 {% endif -%}
 
 {% if "alpine" in target_file %}
@@ -209,6 +214,8 @@ RUN rustup target add aarch64-unknown-linux-gnu
 {% elif "armv6" in target_file %}
 RUN rustup target add arm-unknown-linux-gnueabi
 
+{% elif "armv7" in target_file %}
+RUN rustup target add armv7-unknown-linux-gnueabihf
 {% endif %}
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -140,7 +140,11 @@ ENV USER "root"
 # Install MySQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
+{% if "musl" in build_stage_base_image %}
+    libmysqlclient-dev{{ package_arch_prefix }} \
+{% else %}
     libmariadb-dev{{ package_arch_prefix }} \
+{% endif %}
     && rm -rf /var/lib/apt/lists/*
 
 {% elif "postgresql" in target_file %}

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -37,7 +37,6 @@ RUN apk add --no-cache --upgrade \
     curl \
     tar
 {% else %}
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8
@@ -76,14 +75,16 @@ FROM {{ build_stage_base_image }} as build
 {% if "sqlite" in target_file %}
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
+
 {% elif "mysql" in target_file %}
 # set mysql backend
 ARG DB=mysql
+
 {% elif "postgresql" in target_file %}
 # set postgresql backend
 ARG DB=postgresql
-{% endif %}
 
+{% endif %}
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8
@@ -244,8 +245,8 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 
 {% if "amd64" not in target_file %}
 RUN [ "cross-build-start" ]
-{% endif %}
 
+{% endif %}
 # Install needed libraries
 {% if "alpine" in runtime_stage_base_image %}
 RUN apk add --no-cache \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -86,8 +86,7 @@ RUN rustup set profile minimal
 {% if "alpine" in target_file %}
 ENV USER "root"
 
-{% endif %}
-{% if "aarch64" in target_file or "armv" in target_file %}
+{% elif "aarch64" in target_file or "armv" in target_file %}
 # Install required build libs for {{ package_arch_name }} architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -1,3 +1,6 @@
+{{ "# This file was generated using a Jinja2 template." }}
+{{ "# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's." }}
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -43,8 +43,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,9 @@
+OBJECTS := $(shell find -mindepth 2 -name 'Dockerfile*')
+
+all: $(OBJECTS)
+
+%/Dockerfile: Dockerfile.j2 render_template
+	./render_template "$<" "{\"target_file\":\"$@\"}" > "$@"
+
+%/Dockerfile.alpine: Dockerfile.j2 render_template
+	./render_template "$<" "{\"target_file\":\"$@\"}" > "$@"

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/aarch64-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -42,9 +48,17 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
+# Install MySQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libmariadb-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl arm64 libs
+# Install required build libs for arm64 architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture arm64 \
@@ -52,19 +66,32 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:arm64 \
-        libc6-dev:arm64 \
-        libmariadb-dev:arm64
+        libc6-dev:arm64
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
 
 ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
@@ -86,14 +113,15 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     libmariadbclient-dev \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -37,6 +37,16 @@ ARG DB=mysql
 # Don't download rust docs
 RUN rustup set profile minimal
 
+# Install required build libs for arm64 architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev:arm64 \
+        libc6-dev:arm64
+
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
@@ -57,16 +67,6 @@ RUN apt-get update && apt-get install -y \
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Install required build libs for arm64 architecture.
-RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
-        /etc/apt/sources.list.d/deb-src.list \
-    && dpkg --add-architecture arm64 \
-    && apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        libssl-dev:arm64 \
-        libc6-dev:arm64
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set mysql backend
 ARG DB=mysql
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/aarch64-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -77,6 +77,8 @@ ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
+RUN rustup target add aarch64-unknown-linux-gnu
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -92,7 +94,6 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
-RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
 ######################## RUNTIME IMAGE  ########################

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/aarch64-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -25,7 +31,7 @@ RUN ls
 # we need the Rust compiler and Cargo tooling
 FROM rust:1.40 as build
 
-# set sqlite as default for DB ARG for backward comaptibility
+# set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
 # Don't download rust docs
@@ -42,9 +48,11 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl arm64 libs
+# Install required build libs for arm64 architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture arm64 \
@@ -54,16 +62,30 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libssl-dev:arm64 \
         libc6-dev:arm64
 
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
 ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
@@ -85,14 +107,15 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -37,6 +37,16 @@ ARG DB=sqlite
 # Don't download rust docs
 RUN rustup set profile minimal
 
+# Install required build libs for arm64 architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev:arm64 \
+        libc6-dev:arm64
+
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
@@ -51,16 +61,6 @@ ENV USER "root"
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Install required build libs for arm64 architecture.
-RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
-        /etc/apt/sources.list.d/deb-src.list \
-    && dpkg --add-architecture arm64 \
-    && apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        libssl-dev:arm64 \
-        libc6-dev:arm64
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/aarch64-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -71,6 +71,8 @@ ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
+RUN rustup target add aarch64-unknown-linux-gnu
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -86,7 +88,6 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
-RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
 ######################## RUNTIME IMAGE  ########################

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -59,7 +59,7 @@ ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set mysql backend
 ARG DB=mysql
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM debian:buster-slim as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -71,6 +77,7 @@ FROM debian:buster-slim
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
+
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y \

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8
@@ -87,7 +86,6 @@ FROM debian:buster-slim
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
-
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y \

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM debian:buster-slim as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -35,7 +35,7 @@ ENV USER "root"
 # Install MySQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
-    libmariadb-dev \
+    libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -1,4 +1,4 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
@@ -15,7 +15,7 @@ RUN apk add --no-cache --upgrade \
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/ash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -32,24 +32,38 @@ RUN rustup set profile minimal
 
 ENV USER "root"
 
-# Install needed libraries
+# Install MySQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
-    libmysqlclient-dev \
+    libmariadb-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-RUN rustup target add x86_64-unknown-linux-musl
-
 # Make sure that we actually build the project
 RUN touch src/main.rs
 
-# Build
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Builds again, this time it'll just be
+# your actual source files being built
 RUN cargo build --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
@@ -62,11 +76,12 @@ ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
+
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \
-        mariadb-connector-c \
         curl \
+        mariadb-connector-c \
         ca-certificates
 
 RUN mkdir /data

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -27,6 +27,12 @@ FROM clux/muslrust:nightly-2019-12-19 as build
 # set mysql backend
 ARG DB=mysql
 
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
 # Don't download rust docs
 RUN rustup set profile minimal
 

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -47,6 +47,8 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+RUN rustup target add x86_64-unknown-linux-musl
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -59,8 +61,6 @@ COPY . .
 
 # Make sure that we actually build the project
 RUN touch src/main.rs
-
-RUN rustup target add x86_64-unknown-linux-musl
 
 # Builds again, this time it'll just be
 # your actual source files being built

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -82,7 +82,6 @@ ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
-
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM debian:buster-slim as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -25,19 +31,13 @@ RUN ls
 # we need the Rust compiler and Cargo tooling
 FROM rust:1.40 as build
 
-# set mysql backend
+# set postgresql backend
 ARG DB=postgresql
 
 # Don't download rust docs
 RUN rustup set profile minimal
 
-# Using bundled SQLite, no need to install it
-# RUN apt-get update && apt-get install -y\
-#    --no-install-recommends \
-#    sqlite3\
-# && rm -rf /var/lib/apt/lists/*
-
-# Install MySQL package
+# Install PostgreSQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     libpq-dev \
@@ -78,13 +78,13 @@ ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 
+
 # Install needed libraries
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     openssl \
     ca-certificates \
     curl \
-    sqlite3 \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set postgresql backend
 ARG DB=postgresql
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8
@@ -87,7 +86,6 @@ FROM debian:buster-slim
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
-
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y \

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM debian:buster-slim as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -27,6 +27,12 @@ FROM clux/muslrust:nightly-2019-12-19 as build
 # set postgresql backend
 ARG DB=postgresql
 
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
 # Don't download rust docs
 RUN rustup set profile minimal
 

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -47,6 +47,8 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+RUN rustup target add x86_64-unknown-linux-musl
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -59,8 +61,6 @@ COPY . .
 
 # Make sure that we actually build the project
 RUN touch src/main.rs
-
-RUN rustup target add x86_64-unknown-linux-musl
 
 # Builds again, this time it'll just be
 # your actual source files being built

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -1,4 +1,4 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
@@ -15,7 +15,7 @@ RUN apk add --no-cache --upgrade \
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/ash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -32,24 +32,38 @@ RUN rustup set profile minimal
 
 ENV USER "root"
 
-# Install needed libraries
+# Install PostgreSQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-RUN rustup target add x86_64-unknown-linux-musl
-
 # Make sure that we actually build the project
 RUN touch src/main.rs
 
-# Build
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Builds again, this time it'll just be
+# your actual source files being built
 RUN cargo build --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
@@ -62,12 +76,12 @@ ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
+
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \
-        postgresql-libs \
         curl \
-        sqlite \
+        postgresql-libs \
         ca-certificates
 
 RUN mkdir /data

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -82,7 +82,6 @@ ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
-
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -1,4 +1,4 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
@@ -31,7 +31,7 @@ RUN ls
 # we need the Rust compiler and Cargo tooling
 FROM rust:1.40 as build
 
-# set sqlite as default for DB ARG for backward comaptibility
+# set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
 # Don't download rust docs
@@ -71,6 +71,7 @@ FROM debian:buster-slim
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
+
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y \

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8
@@ -81,7 +80,6 @@ FROM debian:buster-slim
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
-
 
 # Install needed libraries
 RUN apt-get update && apt-get install -y \

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -2,20 +2,26 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM debian:buster-slim as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -38,7 +38,7 @@ ARG DB=sqlite
 RUN rustup set profile minimal
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM debian:buster-slim as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -27,6 +27,12 @@ FROM clux/muslrust:nightly-2019-12-19 as build
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
 # Don't download rust docs
 RUN rustup set profile minimal
 

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -76,7 +76,6 @@ ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
-
 # Install needed libraries
 RUN apk add --no-cache \
         openssl \

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -33,7 +33,7 @@ RUN rustup set profile minimal
 ENV USER "root"
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -41,6 +41,8 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+RUN rustup target add x86_64-unknown-linux-musl
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -53,8 +55,6 @@ COPY . .
 
 # Make sure that we actually build the project
 RUN touch src/main.rs
-
-RUN rustup target add x86_64-unknown-linux-musl
 
 # Builds again, this time it'll just be
 # your actual source files being built

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -1,4 +1,4 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
@@ -15,7 +15,7 @@ RUN apk add --no-cache --upgrade \
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/ash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -24,7 +24,7 @@ RUN ls
 # Musl build image for statically compiled binary
 FROM clux/muslrust:nightly-2019-12-19 as build
 
-# set sqlite as default for DB ARG for backward comaptibility
+# set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
 # Don't download rust docs
@@ -32,18 +32,32 @@ RUN rustup set profile minimal
 
 ENV USER "root"
 
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-RUN rustup target add x86_64-unknown-linux-musl
-
 # Make sure that we actually build the project
 RUN touch src/main.rs
 
-# Build
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Builds again, this time it'll just be
+# your actual source files being built
 RUN cargo build --features ${DB} --release
 
 ######################## RUNTIME IMAGE  ########################
@@ -55,6 +69,7 @@ ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10
 ENV SSL_CERT_DIR=/etc/ssl/certs
+
 
 # Install needed libraries
 RUN apk add --no-cache \
@@ -77,7 +92,6 @@ COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 COPY docker/healthcheck.sh ./healthcheck.sh
 
 HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
-
 
 # Configures the startup!
 WORKDIR /

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -37,6 +37,16 @@ ARG DB=mysql
 # Don't download rust docs
 RUN rustup set profile minimal
 
+# Install required build libs for armel architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture armel \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev:armel \
+        libc6-dev:armel
+
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
@@ -57,16 +67,6 @@ RUN apt-get update && apt-get install -y \
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Install required build libs for armel architecture.
-RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
-        /etc/apt/sources.list.d/deb-src.list \
-    && dpkg --add-architecture armel \
-    && apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        libssl-dev:armel \
-        libc6-dev:armel
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/rpi-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/rpi-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -42,9 +48,17 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
+# Install MySQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libmariadb-dev:armel \
+    && rm -rf /var/lib/apt/lists/*
+
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl armel libs
+# Install required build libs for armel architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armel \
@@ -52,21 +66,32 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:armel \
-        libc6-dev:armel \
-        libmariadb-dev:armel
+        libc6-dev:armel
+
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
 
 ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
-RUN rustup target add arm-unknown-linux-gnueabi
-RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
@@ -90,10 +115,11 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set mysql backend
 ARG DB=mysql
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -77,6 +77,8 @@ ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+RUN rustup target add arm-unknown-linux-gnueabi
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -92,6 +94,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
+RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/rpi-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -25,7 +31,7 @@ RUN ls
 # we need the Rust compiler and Cargo tooling
 FROM rust:1.40 as build
 
-# set sqlite as default for DB ARG for backward comaptibility
+# set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
 # Don't download rust docs
@@ -42,9 +48,11 @@ RUN apt-get update \
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl armel libs
+# Install required build libs for armel architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armel \
@@ -54,18 +62,30 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libssl-dev:armel \
         libc6-dev:armel
 
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
 ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
-RUN rustup target add arm-unknown-linux-gnueabi
-RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
@@ -89,10 +109,11 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/rpi-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -71,6 +71,8 @@ ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
+RUN rustup target add arm-unknown-linux-gnueabi
+
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
@@ -86,6 +88,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
+RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -37,6 +37,16 @@ ARG DB=sqlite
 # Don't download rust docs
 RUN rustup set profile minimal
 
+# Install required build libs for armel architecture.
+RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
+        /etc/apt/sources.list.d/deb-src.list \
+    && dpkg --add-architecture armel \
+    && apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        libssl-dev:armel \
+        libc6-dev:armel
+
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
@@ -51,16 +61,6 @@ ENV USER "root"
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin app
 WORKDIR /app
-
-# Install required build libs for armel architecture.
-RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
-        /etc/apt/sources.list.d/deb-src.list \
-    && dpkg --add-architecture armel \
-    && apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        libssl-dev:armel \
-        libc6-dev:armel
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -59,7 +59,7 @@ ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -37,16 +37,6 @@ ARG DB=mysql
 # Don't download rust docs
 RUN rustup set profile minimal
 
-# Install MySQL package
-RUN apt-get update && apt-get install -y \
-    --no-install-recommends \
-    libmariadb-dev:armhf \
-    && rm -rf /var/lib/apt/lists/*
-
-# Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
-WORKDIR /app
-
 # Install required build libs for armhf architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
@@ -56,6 +46,16 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         --no-install-recommends \
         libssl-dev:armhf \
         libc6-dev:armhf
+
+# Install MySQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libmariadb-dev:armhf \
+    && rm -rf /var/lib/apt/lists/*
+
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
+WORKDIR /app
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/armv7hf-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -31,20 +37,17 @@ ARG DB=mysql
 # Don't download rust docs
 RUN rustup set profile minimal
 
-RUN apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        gcc-arm-linux-gnueabihf \
-    && mkdir -p ~/.cargo \
-    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+# Install MySQL package
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    libmariadb-dev:armhf \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV CARGO_HOME "/root/.cargo"
-ENV USER "root"
-
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl armhf libs
+# Install required build libs for armhf architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armhf \
@@ -52,22 +55,28 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:armhf \
-        libc6-dev:armhf \
-        libmariadb-dev:armhf
+        libc6-dev:armhf
 
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
 
-ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
-ENV CROSS_COMPILE="1"
-ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
-ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
-RUN rustup target add armv7-unknown-linux-gnueabihf
-RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
@@ -91,10 +100,11 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -96,6 +96,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -84,6 +84,11 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
+ENV CROSS_COMPILE="1"
+ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
+ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
+RUN rustup target add armv7-unknown-linux-gnueabihf
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/armv7hf-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -47,6 +47,17 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libssl-dev:armhf \
         libc6-dev:armhf
 
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-arm-linux-gnueabihf \
+    && mkdir -p ~/.cargo \
+    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
 # Install MySQL package
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set mysql backend
 ARG DB=mysql
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -8,10 +8,14 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=C.UTF-8 \
-    TZ=UTC \
-    TERM=xterm-256color
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
+
+RUN echo $TERM
 
 RUN apt update -y \
     && apt install -y \
@@ -33,6 +37,12 @@ FROM rust:1.40 as build
 
 # set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
+
+# Build time options to avoid dpkg warnings and help with reproducible builds.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LANG=C.UTF-8
+ARG TZ=UTC
+ARG TERM=xterm-256color
 
 # Don't download rust docs
 RUN rustup set profile minimal

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -8,7 +8,6 @@ ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LANG=C.UTF-8

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -48,7 +48,7 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libc6-dev:armhf
 
 # Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
+RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Copies over *only* your manifests and build files

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -47,6 +47,17 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libssl-dev:armhf \
         libc6-dev:armhf
 
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        gcc-arm-linux-gnueabihf \
+    && mkdir -p ~/.cargo \
+    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+
+ENV CARGO_HOME "/root/.cargo"
+ENV USER "root"
+
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
 WORKDIR /app

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -90,6 +90,7 @@ RUN touch src/main.rs
 
 # Builds again, this time it'll just be
 # your actual source files being built
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -2,7 +2,7 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM balenalib/armv7hf-debian:buster as vault
+FROM rust:1.40 as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -14,8 +14,6 @@ ARG LANG=C.UTF-8
 ARG TZ=UTC
 ARG TERM=xterm-256color
 
-RUN echo $TERM
-
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -1,21 +1,27 @@
-# Using multistage build: 
+# Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-FROM alpine:3.11 as vault
+FROM balenalib/armv7hf-debian:buster as vault
 
 ENV VAULT_VERSION "v2.12.0b"
 
 ENV URL "https://github.com/dani-garcia/bw_web_builds/releases/download/$VAULT_VERSION/bw_web_$VAULT_VERSION.tar.gz"
 
-RUN apk add --no-cache --upgrade \
-    curl \
-    tar
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    TZ=UTC \
+    TERM=xterm-256color
+
+RUN apt update -y \
+    && apt install -y \
+        curl \
+        tar
 
 RUN mkdir /web-vault
 WORKDIR /web-vault
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
 
 RUN curl -L $URL | tar xz
 RUN ls
@@ -25,26 +31,17 @@ RUN ls
 # we need the Rust compiler and Cargo tooling
 FROM rust:1.40 as build
 
-# set sqlite as default for DB ARG for backward comaptibility
+# set sqlite as default for DB ARG for backward compatibility
 ARG DB=sqlite
 
 # Don't download rust docs
 RUN rustup set profile minimal
 
-RUN apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        gcc-arm-linux-gnueabihf \
-    && mkdir -p ~/.cargo \
-    && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
-
-ENV CARGO_HOME "/root/.cargo"
-ENV USER "root"
-
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
 WORKDIR /app
 
-# Prepare openssl armhf libs
+# Install required build libs for armhf architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armhf \
@@ -54,18 +51,26 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         libssl-dev:armhf \
         libc6-dev:armhf
 
-ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
-ENV CROSS_COMPILE="1"
-ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
-ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
+# Copies over *only* your manifests and build files
+COPY ./Cargo.* ./
+COPY ./rust-toolchain ./rust-toolchain
+COPY ./build.rs ./build.rs
+
+# Builds your dependencies and removes the
+# dummy project, except the target folder
+# This folder contains the compiled dependencies
+RUN cargo build --features ${DB} --release
+RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
 
-# Build
-RUN rustup target add armv7-unknown-linux-gnueabihf
-RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
+# Make sure that we actually build the project
+RUN touch src/main.rs
+
+# Builds again, this time it'll just be
+# your actual source files being built
 
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
@@ -89,10 +94,11 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir /data
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]
 
 VOLUME /data
 EXPOSE 80
+EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -1,3 +1,6 @@
+# This file was generated using a Jinja2 template.
+# Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfile's.
+
 # Using multistage build:
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -16,8 +16,9 @@ ARG TERM=xterm-256color
 
 RUN echo $TERM
 
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
         curl \
         tar
 

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -78,6 +78,11 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
+ENV CROSS_COMPILE="1"
+ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
+ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabihf"
+RUN rustup target add armv7-unknown-linux-gnueabihf
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -37,10 +37,6 @@ ARG DB=sqlite
 # Don't download rust docs
 RUN rustup set profile minimal
 
-# Creates a dummy project used to grab dependencies
-RUN USER=root cargo new --bin app
-WORKDIR /app
-
 # Install required build libs for armhf architecture.
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
@@ -50,6 +46,10 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         --no-install-recommends \
         libssl-dev:armhf \
         libc6-dev:armhf
+
+# Creates a dummy project used to grab dependencies
+RUN USER=root cargo new --bin app
+WORKDIR /app
 
 # Copies over *only* your manifests and build files
 COPY ./Cargo.* ./

--- a/docker/render_template
+++ b/docker/render_template
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os, argparse, json
+
+import jinja2
+
+args_parser = argparse.ArgumentParser()
+args_parser.add_argument('template_file', help='Jinja2 template file to render.')
+args_parser.add_argument('render_vars', help='JSON-encoded data to pass to the templating engine.')
+cli_args = args_parser.parse_args()
+
+render_vars = json.loads(cli_args.render_vars)
+environment = jinja2.Environment(
+	loader=jinja2.FileSystemLoader(os.getcwd()),
+	trim_blocks=True,
+)
+print(environment.get_template(cli_args.template_file).render(render_vars))


### PR DESCRIPTION
No need to use two different base images. Debian buster is pulled later anyway so we can just use it for the vault stage as well.

My reason for this change is partly to avoid redundancy and partly to make it easier to build everything yourself. When all the build environment is based on Debian than you just have to figure out how to build a Debian Docker base image (ref: https://github.com/ypid/docker-makefile).

~~WIP: This PR is incomplete. I first wanted to check if this is acceptable two you because I put together a short script to replace this in all the Dockerfiles.~~

I assume the broken windows CI build is not my fault. Why support Windows anyway ;-)