### PR TITLE
Fixes #635 - Unique constraint violation when using U2F tokens on PostgreSQL

### DIFF
--- a/src/db/models/two_factor.rs
+++ b/src/db/models/two_factor.rs
@@ -76,12 +76,9 @@ impl TwoFactor {
         // We need to make sure we're not going to violate the unique constraint on user_uuid and atype.
         // This happens automatically on other DBMS backends due to replace_into(). PostgreSQL does
         // not support multiple constraints on ON CONFLICT clauses.
-        let result: EmptyResult = diesel::delete(twofactor::table.filter(twofactor::user_uuid.eq(&self.user_uuid)).filter(twofactor::atype.eq(&self.atype)))
+        diesel::delete(twofactor::table.filter(twofactor::user_uuid.eq(&self.user_uuid)).filter(twofactor::atype.eq(&self.atype)))
             .execute(&**conn)
-            .map_res("Error deleting twofactor for insert");
-        if result.is_err() {
-            return result;
-        }
+            .map_res("Error deleting twofactor for insert")?;
 
         diesel::insert_into(twofactor::table)
             .values(self)


### PR DESCRIPTION
Because of differences in how .on_conflict() works compared to .replace_into() the PostgreSQL backend wasn't correctly ensuring the unique constraint on user_uuid and atype wasn't getting violated.

This change simply issues a DELETE on the unique constraint prior to the insert to ensure uniqueness. PostgreSQL does not support multiple constraints in ON CONFLICT clauses.

Please let me know if you'd like to see any changes.