### PR TITLE
Do not disable invitations via admin API

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -153,10 +153,6 @@ fn invite_user(data: Json<InviteData>, _token: AdminToken, conn: DbConn) -> Empt
         err!("User already exists")
     }
 
-    if !CONFIG.invitations_allowed() {
-        err!("Invitations are not allowed")
-    }
-
     let mut user = User::new(email);
     user.save(&conn)?;
 

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -319,10 +319,9 @@ impl Invitation {
     }
 
     pub fn take(mail: &str, conn: &DbConn) -> bool {
-        CONFIG.invitations_allowed()
-            && match Self::find_by_mail(mail, &conn) {
-                Some(invitation) => invitation.delete(&conn).is_ok(),
-                None => false,
-            }
+        match Self::find_by_mail(mail, &conn) {
+            Some(invitation) => invitation.delete(&conn).is_ok(),
+            None => false,
+        }
     }
 }


### PR DESCRIPTION
This was brought up today:

https://github.com/dani-garcia/bitwarden_rs/issues/752#issuecomment-586715073

I don't think it makes much sense in checking whether admin has the
right to send invitation as admin can change the setting anyway.

Removing the condition allows users to forbid regular users from
inviting new users to server while still preserving the option to do so
via the admin API.