### PR TITLE
Fix escaping of SMTP_AUTH_MECHANISM in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -187,7 +187,7 @@
 # SMTP_SSL=true
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
-# SMTP_AUTH_MECHANISM="Plain"
+# SMTP_AUTH_MECHANISM="\"Plain\""
 # SMTP_TIMEOUT=15
 
 # vim: syntax=ini


### PR DESCRIPTION
Correctly escapes the quotation marks of the `SMTP_AUTH_MECHANISM` variable in `.env.template`. 
The file is sourced by the shell and swallows the simple quotation marks. 
However, we need a proper JSON value, that is, it has to have quotation marks.
Otherwise, we get the error
```
thread '<unnamed>' panicked at 'Failure to parse mechanism. Is it proper Json? Eg. `"Plain"` not `Plain`', src/mail.rs:52:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is fixed by adding escaped quotation marks.