### PR TITLE
Use opportunistic TLS in SMTP connections

### DIFF
--- a/src/mail.rs
+++ b/src/mail.rs
@@ -18,21 +18,21 @@ use chrono::NaiveDateTime;
 fn mailer() -> SmtpTransport {
     let host = CONFIG.smtp_host().unwrap();
 
+    let tls = TlsConnector::builder()
+        .min_protocol_version(Some(Protocol::Tlsv11))
+        .build()
+        .unwrap();
+
+    let tls_params = ClientTlsParameters::new(host.clone(), tls);
+
     let client_security = if CONFIG.smtp_ssl() {
-        let tls = TlsConnector::builder()
-            .min_protocol_version(Some(Protocol::Tlsv11))
-            .build()
-            .unwrap();
-
-        let params = ClientTlsParameters::new(host.clone(), tls);
-
         if CONFIG.smtp_explicit_tls() {
-            ClientSecurity::Wrapper(params)
+            ClientSecurity::Wrapper(tls_params)
         } else {
-            ClientSecurity::Required(params)
+            ClientSecurity::Required(tls_params)
         }
     } else {
-        ClientSecurity::None
+        ClientSecurity::Opportunistic(tls_params)
     };
 
     use std::time::Duration;


### PR DESCRIPTION
If SSL is disabled, the SMTP `ClientSecurity` of the `lettre` crate defaults to `None`, that is, an insecure connection. 
This is changed to `Opportunistic`, which uses TLS if available. 
If TLS is not available, an insecure connection is used (i.e., this change is backward compatible).