### PR TITLE
Fix alpine build with openssl crate as default

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -35,7 +35,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 {% endraw %}
@@ -71,6 +71,7 @@ RUN rustup set profile minimal
 
 {% if "alpine" in target_file %}
 ENV USER "root"
+ENV RUSTFLAGS='-C link-arg=-s'
 
 {% elif "aarch64" in target_file or "armv" in target_file %}
 # Install required build libs for {{ package_arch_name }} architecture.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(proc_macro_hygiene, vec_remove_item, try_trait, ip)]
 #![recursion_limit = "256"]
 
-#[cfg(feature = "openssl")]
 extern crate openssl;
 #[macro_use]
 extern crate rocket;


### PR DESCRIPTION
Make openssl crate as default (non feature-flipped)
Make static build