### PR TITLE
Fixed issue #908

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -307,6 +307,25 @@ pub struct OrgHeaders {
     pub org_user_type: UserOrgType,
 }
 
+// org_id is usually the second param ("/organizations/<org_id>")
+// But there are cases where it is located in a query value.
+// First check the param, if this is not a valid uuid, we will try the query value.
+fn get_org_id(request: &Request) -> Option<String> {
+    if let Some(Ok(org_id)) = request.get_param::<String>(1) {
+        if uuid::Uuid::parse_str(&org_id).is_ok() {
+            return Some(org_id);
+        }
+    }
+
+    if let Some(Ok(org_id)) = request.get_query_value::<String>("organizationId") {
+        if uuid::Uuid::parse_str(&org_id).is_ok() {
+            return Some(org_id);
+        }
+    }
+
+    None
+}
+
 impl<'a, 'r> FromRequest<'a, 'r> for OrgHeaders {
     type Error = &'static str;
 
@@ -315,60 +334,40 @@ impl<'a, 'r> FromRequest<'a, 'r> for OrgHeaders {
             Outcome::Forward(_) => Outcome::Forward(()),
             Outcome::Failure(f) => Outcome::Failure(f),
             Outcome::Success(headers) => {
-                // org_id is usually the second param ("/organizations/<org_id>")
-                // But there are cases where it is located in a query value.
-                // First check the param, if this is not a valid uuid, we will try the query value.
-                let query_org_id = match request.get_query_value::<String>("organizationId") {
-                    Some(Ok(query_org_id)) => { query_org_id }
-                    _ => { "".into() }
-                };
-                let param_org_id = match request.get_param::<String>(1) {
-                    Some(Ok(param_org_id)) => { param_org_id }
-                    _ => { "".into() }
-                };
+                match get_org_id(request) {
+                    Some(org_id) => {
+                        let conn = match request.guard::<DbConn>() {
+                            Outcome::Success(conn) => conn,
+                            _ => err_handler!("Error getting DB"),
+                        };
 
-                let org_uuid: _ = match uuid::Uuid::parse_str(&param_org_id) {
-                    Ok(uuid) => uuid,
-                    _ => match uuid::Uuid::parse_str(&query_org_id) {
-                        Ok(uuid) => uuid,
-                        _ => err_handler!("Error getting the organization id"),
-                    }
-                };
-
-                let org_id: &str = &org_uuid.to_string();
-                if !org_id.is_empty() {
-                    let conn = match request.guard::<DbConn>() {
-                        Outcome::Success(conn) => conn,
-                        _ => err_handler!("Error getting DB"),
-                    };
-
-                    let user = headers.user;
-                    let org_user = match UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn) {
-                        Some(user) => {
-                            if user.status == UserOrgStatus::Confirmed as i32 {
-                                user
-                            } else {
-                                err_handler!("The current user isn't confirmed member of the organization")
+                        let user = headers.user;
+                        let org_user = match UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn) {
+                            Some(user) => {
+                                if user.status == UserOrgStatus::Confirmed as i32 {
+                                    user
+                                } else {
+                                    err_handler!("The current user isn't confirmed member of the organization")
+                                }
                             }
-                        }
-                        None => err_handler!("The current user isn't member of the organization"),
-                    };
+                            None => err_handler!("The current user isn't member of the organization"),
+                        };
 
-                    Outcome::Success(Self {
-                        host: headers.host,
-                        device: headers.device,
-                        user,
-                        org_user_type: {
-                            if let Some(org_usr_type) = UserOrgType::from_i32(org_user.atype) {
-                                org_usr_type
-                            } else {
-                                // This should only happen if the DB is corrupted
-                                err_handler!("Unknown user type in the database")
-                            }
-                        },
-                    })
-                } else {
-                    err_handler!("Error getting the organization id")
+                        Outcome::Success(Self {
+                            host: headers.host,
+                            device: headers.device,
+                            user,
+                            org_user_type: {
+                                if let Some(org_usr_type) = UserOrgType::from_i32(org_user.atype) {
+                                    org_usr_type
+                                } else {
+                                    // This should only happen if the DB is corrupted
+                                    err_handler!("Unknown user type in the database")
+                                }
+                            },
+                        })
+                    },
+                    _ => err_handler!("Error getting the organization id"),
                 }
             }
         }


### PR DESCRIPTION
The organization uuid is most of the time within the uri path as a
parameter. But sometimes it only is there as a query value.

This fix checks both, and returns the uuid when possible.

It also fixes the purge/delete functions within the org settings.