### PR TITLE
Healthcheck fixes/optimizations

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -287,9 +287,9 @@ COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs
 COPY --from=build app/target/release/bitwarden_rs .
 {% endif %}
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -124,9 +124,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -118,9 +118,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -92,9 +92,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -94,9 +94,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -92,9 +92,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -94,9 +94,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -86,9 +86,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -88,9 +88,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -124,9 +124,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -118,9 +118,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -123,9 +123,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -12,7 +12,7 @@
 #  - From the console, with the following commands:
 #      docker pull bitwardenrs/web-vault:v2.12.0e
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.12.0e
-#      
+#
 #  - To do the opposite, and get the tag from the hash, you can do:
 #      docker image inspect --format "{{.RepoTags}}" bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c
 FROM bitwardenrs/web-vault@sha256:feb3f46d15738191b9043be4cdb1be2c0078ed411e7b7be73a2f4fcbca01e13c as vault
@@ -117,9 +117,9 @@ COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs .
 
-COPY docker/healthcheck.sh ./healthcheck.sh
+COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=30s --timeout=3s CMD sh healthcheck.sh || exit 1
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -49,4 +49,5 @@ base_path="$(get_base_path "${DOMAIN}")"
 if [ -n "${ROCKET_TLS}" ]; then
     s='s'
 fi
-curl --insecure --fail "http${s}://localhost:${ROCKET_PORT}${base_path}/alive" || exit 1
+curl --insecure --fail --silent --show-error \
+     "http${s}://localhost:${ROCKET_PORT}${base_path}/alive" || exit 1


### PR DESCRIPTION
* Switch healthcheck interval/timeout from 30s/3s to 60s/10s.
  30s interval is arguably overkill, and 3s timeout is definitely too short
  for lower end machines.
* Use HEALTHCHECK CMD exec form to avoid superfluous `sh` invocations.
* Add `--silent --show-error` flags to curl call to avoid progress meter being
  shown in healthcheck logs.