### PR TITLE
Introduce db connection max pool size configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -333,6 +333,9 @@ make_config! {
         /// Log level
         log_level:              String, false,  def,    "Info".to_string();
 
+        /// Database connection pool max size.
+        db_connection_pool_max_size: u32,true,  def,    10;
+
         /// Enable DB WAL |> Turning this off might lead to worse performance, but might help if using bitwarden_rs on some exotic filesystems,
         /// that do not support WAL. Please make sure you read project wiki on the topic before changing this setting.
         enable_db_wal:          bool,   false,  def,    true;
@@ -425,7 +428,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
 
     let dom = cfg.domain.to_lowercase();
     if !dom.starts_with("http://") && !dom.starts_with("https://") {
-        err!("DOMAIN variable needs to contain the protocol (http, https). Use 'http[s]://bw.example.com' instead of 'bw.example.com'"); 
+        err!("DOMAIN variable needs to contain the protocol (http, https). Use 'http[s]://bw.example.com' instead of 'bw.example.com'");
     }
 
     if let Some(ref token) = cfg.admin_token {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -42,8 +42,11 @@ pub mod schema;
 /// Initializes a database pool.
 pub fn init_pool() -> Pool {
     let manager = ConnectionManager::new(CONFIG.database_url());
-
-    r2d2::Pool::builder().build(manager).expect("Failed to create pool")
+    println!(CONFIG.db_connection_pool_max_size())
+    r2d2::Pool::builder()
+        .max_size(CONFIG.db_connection_pool_max_size())
+        .build(manager)
+        .expect("Failed to create pool")
 }
 
 pub fn get_connection() -> Result<Connection, ConnectionError> {


### PR DESCRIPTION
How many connections used in the pool size could be dynamic in order to
adapt to any environment. This value can now be set by using
DB_CONNECTION_POOL_MAX_SIZE.