### PR TITLE
Domain whitelist cleanup and fixes

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -485,7 +485,11 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
         let user = match User::find_by_mail(&email, &conn) {
             None => {
                 if !CONFIG.invitations_allowed() {
-                    err!(format!("User email does not exist: {}", email))
+                    err!(format!("User does not exist: {}", email))
+                }
+
+                if !CONFIG.signups_domains_whitelist().is_empty() && !CONFIG.is_email_domain_whitelisted(&email) {
+                    err!("Email domain not eligible for invitations")
                 }
 
                 if !CONFIG.mail_enabled() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -566,7 +566,7 @@ impl Config {
             warn!("Failed to parse email address '{}'", email);
             return false;
         }
-        let email_domain = e[0];
+        let email_domain = e[0].to_lowercase();
         let whitelist = self.signups_domains_whitelist();
 
         !whitelist.is_empty() && whitelist.split(',').any(|d| d.trim() == email_domain)


### PR DESCRIPTION
* Make `SIGNUPS_DOMAINS_WHITELIST` override the `SIGNUPS_ALLOWED` setting.
  Otherwise, a common pitfall is to set `SIGNUPS_DOMAINS_WHITELIST` without
  realizing that `SIGNUPS_ALLOWED=false` must also be set.

* Whitespace is now accepted in `SIGNUPS_DOMAINS_WHITELIST`. That is,
  `foo.com, bar.com` is now equivalent to `foo.com,bar.com`.

* Add validation on `SIGNUPS_DOMAINS_WHITELIST`. For example, `foo.com,`
  is rejected as containing an empty token.

* Make org owner invitations respect the email domain whitelist.
  This closes a loophole where org owners can invite new users from any domain.