### PR TITLE
Fixed issue #965

### DIFF
--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -5,6 +5,7 @@ use crate::CONFIG;
 
 #[derive(Debug, Identifiable, Queryable, Insertable, Associations, AsChangeset)]
 #[table_name = "attachments"]
+#[changeset_options(treat_none_as_null="true")]
 #[belongs_to(Cipher, foreign_key = "cipher_uuid")]
 #[primary_key(id)]
 pub struct Attachment {

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -7,6 +7,7 @@ use super::{
 
 #[derive(Debug, Identifiable, Queryable, Insertable, Associations, AsChangeset)]
 #[table_name = "ciphers"]
+#[changeset_options(treat_none_as_null="true")]
 #[belongs_to(User, foreign_key = "user_uuid")]
 #[belongs_to(Organization, foreign_key = "organization_uuid")]
 #[primary_key(uuid)]

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -5,6 +5,7 @@ use crate::CONFIG;
 
 #[derive(Debug, Identifiable, Queryable, Insertable, Associations, AsChangeset)]
 #[table_name = "devices"]
+#[changeset_options(treat_none_as_null="true")]
 #[belongs_to(User, foreign_key = "user_uuid")]
 #[primary_key(uuid)]
 pub struct Device {

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -6,6 +6,7 @@ use crate::CONFIG;
 
 #[derive(Debug, Identifiable, Queryable, Insertable, AsChangeset)]
 #[table_name = "users"]
+#[changeset_options(treat_none_as_null="true")]
 #[primary_key(uuid)]
 pub struct User {
     pub uuid: String,


### PR DESCRIPTION
PostgreSQL updates/inserts ignored None/null values.
This is nice for new entries, but not for updates.
Added derive option to allways add these none/null values for Option<>
variables.

This solves issue #965