### PR TITLE
Delete the call to the map file

### DIFF
--- a/src/static/scripts/bootstrap.css
+++ b/src/static/scripts/bootstrap.css
@@ -10035,4 +10035,3 @@ a.text-dark:hover, a.text-dark:focus {
     border-color: #dee2e6;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
The file bootstrap.css.map is missing, the reference can be deleted.
Or else you have to add the file.