### PR TITLE
Extend collection response models

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -83,7 +83,10 @@ fn sync(data: Form<SyncData>, headers: Headers, conn: DbConn) -> JsonResult {
     let folders_json: Vec<Value> = folders.iter().map(Folder::to_json).collect();
 
     let collections = Collection::find_by_user_uuid(&headers.user.uuid, &conn);
-    let collections_json: Vec<Value> = collections.iter().map(Collection::to_json).collect();
+    let collections_json: Vec<Value> = collections
+        .iter()
+        .map(|coll| coll.to_json(&headers.user.uuid, &conn, "collectionDetails"))
+        .collect();
 
     let policies = OrgPolicy::find_by_user(&headers.user.uuid, &conn);
     let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -192,7 +192,7 @@ fn get_user_collections(headers: Headers, conn: DbConn) -> JsonResult {
         "Data":
             Collection::find_by_user_uuid(&headers.user.uuid, &conn)
             .iter()
-            .map(Collection::to_json)
+            .map(|coll| coll.to_json(&headers.user.uuid, &conn, "collectionDetails"))
             .collect::<Value>(),
         "Object": "list",
         "ContinuationToken": null,
@@ -205,7 +205,7 @@ fn get_org_collections(org_id: String, _headers: AdminHeaders, conn: DbConn) -> 
         "Data":
             Collection::find_by_organization(&org_id, &conn)
             .iter()
-            .map(Collection::to_json)
+            .map(|coll| coll.to_json("", &conn, "collection"))
             .collect::<Value>(),
         "Object": "list",
         "ContinuationToken": null,
@@ -229,7 +229,7 @@ fn post_organization_collections(
     let collection = Collection::new(org.uuid, data.Name);
     collection.save(&conn)?;
 
-    Ok(Json(collection.to_json()))
+    Ok(Json(collection.to_json("", &conn, "collection")))
 }
 
 #[put("/organizations/<org_id>/collections/<col_id>", data = "<data>")]
@@ -270,7 +270,7 @@ fn post_organization_collection_update(
     collection.name = data.Name;
     collection.save(&conn)?;
 
-    Ok(Json(collection.to_json()))
+    Ok(Json(collection.to_json("", &conn, "collection")))
 }
 
 #[delete("/organizations/<org_id>/collections/<col_id>/user/<org_user_id>")]
@@ -355,7 +355,7 @@ fn get_org_collection_detail(org_id: String, coll_id: String, headers: AdminHead
                 err!("Collection is not owned by organization")
             }
 
-            Ok(Json(collection.to_json()))
+            Ok(Json(collection.to_json(&headers.user.uuid, &conn, "collectionGroupDetails")))
         }
     }
 }

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -23,13 +23,23 @@ impl Collection {
         }
     }
 
-    pub fn to_json(&self) -> Value {
-        json!({
+    pub fn to_json(&self, user_uuid: &str, conn: &DbConn, resp_model: &str) -> Value {
+        let mut json_object = json!({
             "Id": self.uuid,
             "OrganizationId": self.org_uuid,
             "Name": self.name,
-            "Object": "collection",
-        })
+            "Object": resp_model,
+            "ExternalId": "", //NOT_IMPLEMENTED
+        });
+
+        if resp_model == "collectionDetails" {
+            json_object["ReadOnly"] = json!(!self.is_writable_by_user(&user_uuid, &conn));
+        } else if resp_model == "collectionGroupDetails" {
+            json_object["ExternalId"] = json!("Not supported in bitwarden_rs"); //NOT_IMPLEMENTED
+            json_object["Groups"] = json!([]); //NOT_IMPLEMENTED
+        }
+
+        json_object
     }
 }
 


### PR DESCRIPTION
Extend collection response models to include collection, collectionDetails, and collectionGroupDetails

Edit: This fixes read only collections being listed in add/edit cipher for an organization.  It also sets the ExternalId to "Not supported in bitwarden_rs" for collectionGroupDetails, which will be displayed edit collection.