### PR TITLE
Extend cipher and require collection

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -208,6 +208,11 @@ fn post_ciphers_admin(data: JsonUpcase<ShareCipherData>, headers: Headers, conn:
 fn _post_ciphers_admin(data: JsonUpcase<ShareCipherData>, headers: Headers, conn: DbConn, nt: Notify, resp_model: &str) -> JsonResult {
     let data: ShareCipherData = data.into_inner().data;
 
+    // Require a collection, otherwise it will be saved as "Unassigned" without regard to read_only
+    if data.CollectionIds.is_empty() {
+        err!("You must select at least one collection.")
+    }
+
     let mut cipher = Cipher::new(data.Cipher.Type, data.Cipher.Name.clone());
     cipher.user_uuid = Some(headers.user.uuid.clone());
     cipher.save(&conn)?;

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -425,7 +425,7 @@ fn get_org_details(data: Form<OrgIdData>, headers: Headers, conn: DbConn) -> Jso
     let ciphers = Cipher::find_by_org(&data.organization_id, &conn);
     let ciphers_json: Vec<Value> = ciphers
         .iter()
-        .map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn))
+        .map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn, "cipherMiniDetails"))
         .collect();
 
     Ok(Json(json!({


### PR DESCRIPTION
Extend cipher response models to include cipher, cipherMini, cipherDetails, and cipherMiniDetails.
Require a collection when adding a cipher to an organization.

Edit: This PR plus #990 fixes #971 (read only collections showing in add/edit cipher and cipher creation in "unassigned collection" when the user should be read only)