### PR TITLE
Use format! for rounding to fix arm issue

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -242,9 +242,7 @@ pub fn get_display_size(size: i32) -> String {
         }
     }
 
-    // Round to two decimals
-    let size = ((size * 100.) as f32).round() / 100.;
-    format!("{} {}", size, UNITS[unit_counter])
+    format!("{:.2} {}", size, UNITS[unit_counter])
 }
 
 pub fn get_uuid() -> String {


### PR DESCRIPTION
As discussed in the matrix chat, I fixed the rounding issue on arm by using format! to get a 2 digit precision
