### PR TITLE
Don't HTML-escape email subject lines

### DIFF
--- a/src/static/templates/email/invite_accepted.hbs
+++ b/src/static/templates/email/invite_accepted.hbs
@@ -1,4 +1,4 @@
-Invitation accepted
+Invitation to {{{org_name}}} accepted
 <!---------------->
 <html>
 <p>

--- a/src/static/templates/email/invite_accepted.html.hbs
+++ b/src/static/templates/email/invite_accepted.html.hbs
@@ -1,4 +1,4 @@
-Invitation accepted
+Invitation to {{{org_name}}} accepted
 <!---------------->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #333; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0;">
    <head>

--- a/src/static/templates/email/invite_confirmed.hbs
+++ b/src/static/templates/email/invite_confirmed.hbs
@@ -1,4 +1,4 @@
-Invitation to {{org_name}} confirmed
+Invitation to {{{org_name}}} confirmed
 <!---------------->
 <html>
 <p>

--- a/src/static/templates/email/invite_confirmed.html.hbs
+++ b/src/static/templates/email/invite_confirmed.html.hbs
@@ -1,4 +1,4 @@
-Invitation to {{org_name}} confirmed
+Invitation to {{{org_name}}} confirmed
 <!---------------->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #333; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0;">
    <head>

--- a/src/static/templates/email/new_device_logged_in.hbs
+++ b/src/static/templates/email/new_device_logged_in.hbs
@@ -1,4 +1,4 @@
-New Device Logged In From {{device}}
+New Device Logged In From {{{device}}}
 <!---------------->
 <html>
 <p>

--- a/src/static/templates/email/new_device_logged_in.html.hbs
+++ b/src/static/templates/email/new_device_logged_in.html.hbs
@@ -1,4 +1,4 @@
-New Device Logged In From {{device}}
+New Device Logged In From {{{device}}}
 <!---------------->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #333; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0;">
    <head>

--- a/src/static/templates/email/send_org_invite.hbs
+++ b/src/static/templates/email/send_org_invite.hbs
@@ -1,4 +1,4 @@
-Join {{org_name}}
+Join {{{org_name}}}
 <!---------------->
 <html>
 <p>

--- a/src/static/templates/email/send_org_invite.html.hbs
+++ b/src/static/templates/email/send_org_invite.html.hbs
@@ -1,4 +1,4 @@
-Join {{org_name}}
+Join {{{org_name}}}
 <!---------------->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #333; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0;">
    <head>


### PR DESCRIPTION
For example, this causes org names like `X&Y` to appear as `X&amp;Y`.