### PR TITLE
Admin interface

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -253,13 +253,15 @@ fn get_users_json(_token: AdminToken, conn: DbConn) -> JsonResult {
 
 #[get("/users/overview")]
 fn users_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
+    use crate::util::get_display_size;
+
     let users = User::get_all(&conn);
     let users_json: Vec<Value> = users.iter()
     .map(|u| {
         let mut usr = u.to_json(&conn);
-        if let Some(ciphers) = Cipher::count_owned_by_user(&u.uuid, &conn) {
-            usr["cipher_count"] = json!(ciphers);
-        };
+        usr["cipher_count"] = json!(Cipher::count_owned_by_user(&u.uuid, &conn));
+        usr["attachment_count"] = json!(Attachment::count_by_user(&u.uuid, &conn));
+        usr["attachment_size"] = json!(get_display_size(Attachment::size_by_user(&u.uuid, &conn) as i32));
         usr
     }).collect();
 

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -130,6 +130,16 @@ impl Attachment {
         result.unwrap_or(0)
     }
 
+    pub fn count_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
+        attachments::table
+            .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))
+            .filter(ciphers::user_uuid.eq(user_uuid))
+            .count()
+            .first::<i64>(&**conn)
+            .ok()
+            .unwrap_or(0)
+    }
+
     pub fn size_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
         let result: Option<i64> = attachments::table
             .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -150,4 +150,14 @@ impl Attachment {
 
         result.unwrap_or(0)
     }
+
+    pub fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+        attachments::table
+            .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))
+            .filter(ciphers::organization_uuid.eq(org_uuid))
+            .count()
+            .first(&**conn)
+            .ok()
+            .unwrap_or(0)
+    }
 }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -370,6 +370,15 @@ impl Cipher {
             .load::<Self>(&**conn).expect("Error loading ciphers")
     }
 
+    pub fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+        ciphers::table
+            .filter(ciphers::organization_uuid.eq(org_uuid))
+            .count()
+            .first::<i64>(&**conn)
+            .ok()
+            .unwrap_or(0)
+    }
+
     pub fn find_by_folder(folder_uuid: &str, conn: &DbConn) -> Vec<Self> {
         folders_ciphers::table.inner_join(ciphers::table)
             .filter(folders_ciphers::folder_uuid.eq(folder_uuid))

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -355,12 +355,13 @@ impl Cipher {
         .load::<Self>(&**conn).expect("Error loading ciphers")
     }
 
-    pub fn count_owned_by_user(user_uuid: &str, conn: &DbConn) -> Option<i64> {
+    pub fn count_owned_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
         ciphers::table
         .filter(ciphers::user_uuid.eq(user_uuid))
         .count()
         .first::<i64>(&**conn)
         .ok()
+        .unwrap_or(0)
     }
 
     pub fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -437,6 +437,15 @@ impl UserOrganization {
             .expect("Error loading user organizations")
     }
 
+    pub fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+        users_organizations::table
+            .filter(users_organizations::org_uuid.eq(org_uuid))
+            .count()
+            .first::<i64>(&**conn)
+            .ok()
+            .unwrap_or(0)
+    }
+
     pub fn find_by_org_and_type(org_uuid: &str, atype: i32, conn: &DbConn) -> Vec<Self> {
         users_organizations::table
             .filter(users_organizations::org_uuid.eq(org_uuid))

--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -9,24 +9,26 @@
                     <dt class="col-sm-5">Server Installed
                         <span class="badge badge-success d-none" id="server-success" title="Latest version is installed.">Ok</span>
                         <span class="badge badge-warning d-none" id="server-warning" title="There seems to be an update available.">Update</span>
-                        <span class="badge badge-danger d-none" id="server-failed" title="Unable to determine latest version.">Unknown</span>
                     </dt>
                     <dd class="col-sm-7">
                         <span id="server-installed">{{version}}</span>
                     </dd>
-                    <dt class="col-sm-5">Server Latest</dt>
+                    <dt class="col-sm-5">Server Latest
+                        <span class="badge badge-danger d-none" id="server-failed" title="Unable to determine latest version.">Unknown</span>
+                    </dt>
                     <dd class="col-sm-7">
                         <span id="server-latest">{{diagnostics.latest_release}}<span id="server-latest-commit" class="d-none">-{{diagnostics.latest_commit}}</span></span>
                     </dd>
                     <dt class="col-sm-5">Web Installed
                         <span class="badge badge-success d-none" id="web-success" title="Latest version is installed.">Ok</span>
                         <span class="badge badge-warning d-none" id="web-warning" title="There seems to be an update available.">Update</span>
-                        <span class="badge badge-danger d-none" id="web-failed" title="Unable to determine latest version.">Unknown</span>
                     </dt>
                     <dd class="col-sm-7">
                         <span id="web-installed">{{diagnostics.web_vault_version}}</span>
                     </dd>
-                    <dt class="col-sm-5">Web Latest</dt>
+                    <dt class="col-sm-5">Web Latest
+                        <span class="badge badge-danger d-none" id="web-failed" title="Unable to determine latest version.">Unknown</span>
+                    </dt>
                     <dd class="col-sm-7">
                         <span id="web-latest">{{diagnostics.latest_web_build}}</span>
                     </dd>

--- a/src/static/templates/admin/organizations.hbs
+++ b/src/static/templates/admin/organizations.hbs
@@ -2,24 +2,45 @@
     <div id="organizations-block" class="my-3 p-3 bg-white rounded shadow">
         <h6 class="border-bottom pb-2 mb-0">Organizations</h6>
 
-        <div id="organizations-list">
-            {{#each organizations}}
-            <div class="media pt-3">
-                <img class="mr-2 rounded identicon" data-src="{{Name}}_{{BillingEmail}}">
-                <div class="media-body pb-3 mb-0 small border-bottom">
-                    <div class="row justify-content-between">
-                        <div class="col">
+        <div class="table-responsive-xl small">
+            <table class="table table-sm table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th style="width: 24px;" colspan="2">Organization</th>
+                        <th>Users</th>
+                        <th>Items</th>
+                        <th>Attachments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#each organizations}}
+                    <tr>
+                        <td><img class="rounded identicon" data-src="{{Id}}"></td>
+                        <td>
                             <strong>{{Name}}</strong>
-                            {{#if Id}}
-                            <span class="badge badge-success ml-2">{{Id}}</span>
+                            <span class="mr-2">({{BillingEmail}})</span>
+                            <span class="d-block">
+                                <span class="badge badge-success">{{Id}}</span>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-block">{{user_count}}</span>
+                        </td>
+                        <td>
+                            <span class="d-block">{{cipher_count}}</span>
+                        </td>
+                        <td>
+                            <span class="d-block"><strong>Amount:</strong> {{attachment_count}}</span>
+                            {{#if attachment_count}}
+                            <span class="d-block"><strong>Size:</strong> {{attachment_size}}</span>
                             {{/if}}
-                            <span class="d-block">{{BillingEmail}}</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            {{/each}}
+                        </td>
+                    </tr>
+                    {{/each}}
+                </tbody>
+            </table>
         </div>
+        
     </div>
 </main>
 

--- a/src/static/templates/admin/users.hbs
+++ b/src/static/templates/admin/users.hbs
@@ -10,7 +10,8 @@
                     <tr>
                         <th style="width: 24px;">User</th>
                         <th></th>
-                        <th style="width:90px; min-width: 90px;">Items</th>
+                        <th style="width:60px; min-width: 60px;">Items</th>
+                        <th>Attachments</th>
                         <th style="min-width: 140px;">Organizations</th>
                         <th style="width: 140px; min-width: 140px;">Actions</th>
                     </tr>
@@ -36,6 +37,12 @@
                         </td>
                         <td>
                             <span class="d-block">{{cipher_count}}</span>
+                        </td>
+                        <td>
+                            <span class="d-block"><strong>Amount:</strong> {{attachment_count}}</span>
+                            {{#if attachment_count}}
+                            <span class="d-block"><strong>Size:</strong> {{attachment_size}}</span>
+                            {{/if}}
                         </td>
                         <td>
                             {{#each Organizations}}

--- a/src/static/templates/admin/users.hbs
+++ b/src/static/templates/admin/users.hbs
@@ -2,8 +2,6 @@
     <div id="users-block" class="my-3 p-3 bg-white rounded shadow">
         <h6 class="border-bottom pb-2 mb-0">Registered Users</h6>
 
-
-
         <div class="table-responsive-xl small">
             <table class="table table-sm table-striped table-hover">
                 <thead>


### PR DESCRIPTION
Added attachment info per user and some layout fix

Fixed an issue when DNS resolving fails.
In the event of a failed DNS Resolving checking for new versions will
cause a huge delay, and in the end a timeout when loading the page.

- Check if DNS resolving failed, if that is the case, do not check for
  new versions
- Changed `fn get_github_api` to make use of structs
- Added a timeout of 10 seconds for the version check requests
- Moved the "Unknown" lables to the "Latest" lable
- Added the amount and size of the attachments per user
- Changed the items count function a bit
- Some small layout changes

Updated Organizations overview
   
- Changed HTML to match users overview
- Added User count
- Added Org cipher amount
- Added Attachment count and size
