### PR TITLE
Add back openssl crate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![feature(proc_macro_hygiene, try_trait, ip)]
 #![recursion_limit = "256"]
 
+extern crate openssl;
 #[macro_use]
 extern crate rocket;
 #[macro_use]


### PR DESCRIPTION
For whatever reason this is still required in some situation to avoid openssl linking errors.