### PR TITLE
Fixes #1022 cloning with attachments

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -274,7 +274,10 @@ pub fn update_cipher_from_data(
             };
 
             if saved_att.cipher_uuid != cipher.uuid {
-                err!("Attachment is not owned by the cipher")
+                // Warn and break here since cloning ciphers provides attachment data but will not be cloned.
+                // If we error out here it will break the whole cloning and causes empty ciphers to appear.
+                warn!("Attachment is not owned by the cipher");
+                break;
             }
 
             saved_att.akey = Some(attachment.Key);


### PR DESCRIPTION
When a cipher has one or more attachments it wasn't able to be cloned.
This commit fixes that issue.

As a side note:
If someone tried to clone items with attachments using any version before this patch they need to remove the empty entries in there vaults and also remove them else other strange issues could happen.