### PR TITLE
Allow postgres:// in DATABASE_URL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -412,7 +412,9 @@ make_config! {
 
 fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
     let db_url = cfg.database_url.to_lowercase();
-    if cfg!(feature = "sqlite") && (db_url.starts_with("mysql:") || db_url.starts_with("postgresql:")) {
+    if cfg!(feature = "sqlite")
+        && (db_url.starts_with("mysql:") || db_url.starts_with("postgresql:") || db_url.starts_with("postgres:"))
+    {
         err!("`DATABASE_URL` is meant for MySQL or Postgres, while this server is meant for SQLite")
     }
 
@@ -420,7 +422,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         err!("`DATABASE_URL` should start with mysql: when using the MySQL server")
     }
 
-    if cfg!(feature = "postgresql") && !db_url.starts_with("postgresql:") {
+    if cfg!(feature = "postgresql") && !(db_url.starts_with("postgresql:") || db_url.starts_with("postgres:")) {
         err!("`DATABASE_URL` should start with postgresql: when using the PostgreSQL server")
     }
 


### PR DESCRIPTION
This PR adjusts the config validation so that `DATABASE_URL`s of the form `postgres://...` are valid when using the PostgreSQL database backend