### PR TITLE
fix: issue 1045: TLS failures using self hosted email server

### DIFF
--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -90,6 +90,8 @@ COPY docker/healthcheck.sh /healthcheck.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
+COPY docker/bootstrap.sh /bootstrap.sh
+
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/bootstrap.sh"]

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# add any certs the user might have bind mounted
+update-ca-certificates
+
+# start bitwarden
+/bitwarden_rs


### PR DESCRIPTION
This is a fix for issue: https://github.com/dani-garcia/bitwarden_rs/issues/1045

bind mount the certs and run update-ca-certificates on container start

```
volumes:
      - ./data:/data
      - ./certs:/certs
      - ./certs/ABC123-Root-CA.crt:/usr/local/share/ca-certificates/ABC123-Root-CA.crt
      - ./certs/ABC123-Sub1-CA.crt:/usr/local/share/ca-certificates/ABC123-Sub1-CA.crt
```

Now the certs are scanned/added on container start and emails successfully flow

```
docker-compose logs -f

Attaching to bitwardenrs
bitwardenrs  | Updating certificates in /etc/ssl/certs...
bitwardenrs  | 2 added, 0 removed; done.
bitwardenrs  | Running hooks in /etc/ca-certificates/update.d...
bitwardenrs  | done.
bitwardenrs  | /--------------------------------------------------------------------\
bitwardenrs  | |                       Starting Bitwarden_RS                        |
bitwardenrs  | |                      Version 1.15.1-596c9b86                       |
bitwardenrs  | |--------------------------------------------------------------------|
bitwardenrs  | | This is an *unofficial* Bitwarden implementation, DO NOT use the   |
bitwardenrs  | | official channels to report bugs/features, regardless of client.   |
bitwardenrs  | | Send usage/configuration questions or feature requests to:         |
bitwardenrs  | |   https://bitwardenrs.discourse.group/                             |
bitwardenrs  | | Report suspected bugs/issues in the software itself at:            |
bitwardenrs  | |   https://github.com/dani-garcia/bitwarden_rs/issues/new           |
bitwardenrs  | \--------------------------------------------------------------------/

```

![image](https://user-images.githubusercontent.com/46820823/86538751-e5b68400-bec5-11ea-8171-42172fa6a2b5.png)
