### PR TITLE
Add startup script to support init operations

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -288,9 +288,10 @@ COPY --from=build app/target/release/bitwarden_rs .
 {% endif %}
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/aarch64/mysql/Dockerfile
+++ b/docker/aarch64/mysql/Dockerfile
@@ -125,9 +125,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/aarch64/sqlite/Dockerfile
+++ b/docker/aarch64/sqlite/Dockerfile
@@ -119,9 +119,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/mysql/Dockerfile
+++ b/docker/amd64/mysql/Dockerfile
@@ -93,9 +93,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/mysql/Dockerfile.alpine
+++ b/docker/amd64/mysql/Dockerfile.alpine
@@ -96,9 +96,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/postgresql/Dockerfile
+++ b/docker/amd64/postgresql/Dockerfile
@@ -93,9 +93,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/postgresql/Dockerfile.alpine
+++ b/docker/amd64/postgresql/Dockerfile.alpine
@@ -96,9 +96,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/sqlite/Dockerfile
+++ b/docker/amd64/sqlite/Dockerfile
@@ -87,9 +87,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build app/target/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/amd64/sqlite/Dockerfile.alpine
+++ b/docker/amd64/sqlite/Dockerfile.alpine
@@ -90,9 +90,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/armv6/mysql/Dockerfile
+++ b/docker/armv6/mysql/Dockerfile
@@ -125,9 +125,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/armv6/sqlite/Dockerfile
+++ b/docker/armv6/sqlite/Dockerfile
@@ -119,9 +119,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/armv7/mysql/Dockerfile
+++ b/docker/armv7/mysql/Dockerfile
@@ -124,9 +124,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/armv7/sqlite/Dockerfile
+++ b/docker/armv7/sqlite/Dockerfile
@@ -118,9 +118,10 @@ COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/bitwarden_rs .
 
 COPY docker/healthcheck.sh /healthcheck.sh
+COPY docker/start.sh /start.sh
 
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["/bitwarden_rs"]
+CMD ["/start.sh"]

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ -r /etc/bitwarden_rs.sh ]; then
+    . /etc/bitwarden_rs.sh
+fi
+
+if [ -d /etc/bitwarden_rs.d ]; then
+    for f in /etc/bitwarden_rs.d/*.sh; do
+        if [ -r $f ]; then
+            . $f
+        fi
+    done
+fi
+
+exec /bitwarden_rs "${@}"


### PR DESCRIPTION
This is useful for making local customizations upon container start. To use
this feature, mount a script into the container as `/etc/bitwarden_rs.sh`
and/or a directory of scripts as `/etc/bitwarden_rs.d`. In the latter case,
only files with an `.sh` extension are sourced, so files with other
extensions (e.g., data/config files) can reside in the same dir.

Note that the init scripts are run each time the container starts (not just
the first time), so these scripts should be idempotent.