### PR TITLE
Use local time in email notifications for new device logins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "backtrace",
  "chashmap",
  "chrono",
+ "chrono-tz",
  "data-encoding",
  "data-url",
  "diesel",
@@ -275,13 +276,23 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fee792e164f78f5fe0c296cc2eb3688a2ca2b70cdff33040922d298203f0c4"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits",
  "time 0.1.43",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d96be7c3e993c9ee4356442db24ba364c924b6b8331866be6b6952bfe74b9d"
+dependencies = [
+ "chrono",
+ "parse-zoneinfo",
 ]
 
 [[package]]
@@ -1616,6 +1627,15 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.4.0",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,9 @@ ring = "0.16.15"
 # UUID generation
 uuid = { version = "0.8.1", features = ["v4"] }
 
-# Date and time librar for Rust
-chrono = "0.4.12"
+# Date and time libraries
+chrono = "0.4.13"
+chrono-tz = "0.5.2"
 time = "0.2.16"
 
 # TOTP library


### PR DESCRIPTION
In this implementation, the `TZ` environment variable must be set
in order for the formatted output to use a more user-friendly
time zone abbreviation (e.g., `UTC`). Otherwise, the output uses
the time zone's UTC offset (e.g., `+00:00`).