### PR TITLE
Fix soft delete notifications

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -999,11 +999,12 @@ fn _delete_cipher_by_uuid(uuid: &str, headers: &Headers, conn: &DbConn, soft_del
     if soft_delete {
         cipher.deleted_at = Some(chrono::Utc::now().naive_utc());
         cipher.save(&conn)?;
+        nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn));
     } else {
         cipher.delete(&conn)?;
+        nt.send_cipher_update(UpdateType::CipherDelete, &cipher, &cipher.update_users_revision(&conn));
     }
 
-    nt.send_cipher_update(UpdateType::CipherDelete, &cipher, &cipher.update_users_revision(&conn));
     Ok(())
 }
 


### PR DESCRIPTION
A soft-deleted entry should now show up in the trash folder immediately
(previously, an extra sync was required).