### PR TITLE
Add more doc comments for MySQL/PostgreSQL connection URIs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,9 +6,16 @@
 
 ## Database URL
 ## When using SQLite, this is the path to the DB file, default to %DATA_FOLDER%/db.sqlite3
-## When using MySQL, this it is the URL to the DB, including username and password:
-## Format: mysql://[user[:password]@]host/database_name
 # DATABASE_URL=data/db.sqlite3
+## When using MySQL, specify an appropriate connection URI.
+## Details: https://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
+# DATABASE_URL=mysql://user:password@host[:port]/database_name
+## When using PostgreSQL, specify an appropriate connection URI (recommended)
+## or keyword/value connection string.
+## Details:
+## - https://docs.diesel.rs/diesel/pg/struct.PgConnection.html
+## - https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+# DATABASE_URL=postgresql://user:password@host[:port]/database_name
 
 ## Individual folders, these override %DATA_FOLDER%
 # RSA_KEY_FILENAME=data/rsa_key


### PR DESCRIPTION
Note that Diesel implements its own parser for MySQL connection URIs, so it
probably doesn't accept the full range of syntax that would be accepted by
MySQL's client libraries, whereas for PostgreSQL, Diesel simply passes the
connection string/URI to PostgreSQL's libpq for processing.