### PR TITLE
Add a note that settings in .env can be overridden

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,8 @@
 ## Bitwarden_RS Configuration File
 ## Uncomment any of the following lines to change the defaults
+## 
+## Be aware that most of these settings will be overridden if they were changed 
+## in the admin interface. Those overrides are stored within DATA_FOLDER/config.json .
 
 ## Main data folder
 # DATA_FOLDER=data


### PR DESCRIPTION
Just a small attempt to make it more clear that the value of settings in the `.env` file may be ignored in some cases.

I'm not sure on the exact wording, please tell me if you have other suggestions :)
