### PR TITLE
Track favorites on a per-user basis

### DIFF
--- a/migrations/mysql/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/mysql/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,4 +1,13 @@
-DROP TABLE favorites;
-
 ALTER TABLE ciphers
-ADD COLUMN favorite BOOLEAN NOT NULL;
+ADD COLUMN favorite BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Transfer favorite status for user-owned ciphers.
+UPDATE ciphers
+SET favorite = TRUE
+WHERE EXISTS (
+  SELECT * FROM favorites
+  WHERE favorites.user_uuid = ciphers.user_uuid
+    AND favorites.cipher_uuid = ciphers.uuid
+);
+
+DROP TABLE favorites;

--- a/migrations/mysql/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/mysql/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE favorites;
+
+ALTER TABLE ciphers
+ADD COLUMN favorite BOOLEAN NOT NULL;

--- a/migrations/mysql/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/mysql/2020-08-02-025025_add_favorites_table/up.sql
@@ -5,5 +5,12 @@ CREATE TABLE favorites (
   PRIMARY KEY (user_uuid, cipher_uuid)
 );
 
+-- Transfer favorite status for user-owned ciphers.
+INSERT INTO favorites(user_uuid, cipher_uuid)
+SELECT user_uuid, uuid
+FROM ciphers
+WHERE favorite = TRUE
+  AND user_uuid IS NOT NULL;
+
 ALTER TABLE ciphers
 DROP COLUMN favorite;

--- a/migrations/mysql/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/mysql/2020-08-02-025025_add_favorites_table/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE favorites (
+  user_uuid   CHAR(36) NOT NULL REFERENCES users(uuid),
+  cipher_uuid CHAR(36) NOT NULL REFERENCES ciphers(uuid),
+
+  PRIMARY KEY (user_uuid, cipher_uuid)
+);
+
+ALTER TABLE ciphers
+DROP COLUMN favorite;

--- a/migrations/postgresql/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/postgresql/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,4 +1,13 @@
-DROP TABLE favorites;
-
 ALTER TABLE ciphers
-ADD COLUMN favorite BOOLEAN NOT NULL;
+ADD COLUMN favorite BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Transfer favorite status for user-owned ciphers.
+UPDATE ciphers
+SET favorite = TRUE
+WHERE EXISTS (
+  SELECT * FROM favorites
+  WHERE favorites.user_uuid = ciphers.user_uuid
+    AND favorites.cipher_uuid = ciphers.uuid
+);
+
+DROP TABLE favorites;

--- a/migrations/postgresql/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/postgresql/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE favorites;
+
+ALTER TABLE ciphers
+ADD COLUMN favorite BOOLEAN NOT NULL;

--- a/migrations/postgresql/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/postgresql/2020-08-02-025025_add_favorites_table/up.sql
@@ -5,5 +5,12 @@ CREATE TABLE favorites (
   PRIMARY KEY (user_uuid, cipher_uuid)
 );
 
+-- Transfer favorite status for user-owned ciphers.
+INSERT INTO favorites(user_uuid, cipher_uuid)
+SELECT user_uuid, uuid
+FROM ciphers
+WHERE favorite = TRUE
+  AND user_uuid IS NOT NULL;
+
 ALTER TABLE ciphers
 DROP COLUMN favorite;

--- a/migrations/postgresql/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/postgresql/2020-08-02-025025_add_favorites_table/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE favorites (
+  user_uuid   VARCHAR(40) NOT NULL REFERENCES users(uuid),
+  cipher_uuid VARCHAR(40) NOT NULL REFERENCES ciphers(uuid),
+
+  PRIMARY KEY (user_uuid, cipher_uuid)
+);
+
+ALTER TABLE ciphers
+DROP COLUMN favorite;

--- a/migrations/sqlite/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/sqlite/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,4 +1,13 @@
-DROP TABLE favorites;
-
 ALTER TABLE ciphers
-ADD COLUMN favorite BOOLEAN NOT NULL;
+ADD COLUMN favorite BOOLEAN NOT NULL DEFAULT 0; -- FALSE
+
+-- Transfer favorite status for user-owned ciphers.
+UPDATE ciphers
+SET favorite = 1
+WHERE EXISTS (
+  SELECT * FROM favorites
+  WHERE favorites.user_uuid = ciphers.user_uuid
+    AND favorites.cipher_uuid = ciphers.uuid
+);
+
+DROP TABLE favorites;

--- a/migrations/sqlite/2020-08-02-025025_add_favorites_table/down.sql
+++ b/migrations/sqlite/2020-08-02-025025_add_favorites_table/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE favorites;
+
+ALTER TABLE ciphers
+ADD COLUMN favorite BOOLEAN NOT NULL;

--- a/migrations/sqlite/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/sqlite/2020-08-02-025025_add_favorites_table/up.sql
@@ -5,6 +5,13 @@ CREATE TABLE favorites (
   PRIMARY KEY (user_uuid, cipher_uuid)
 );
 
+-- Transfer favorite status for user-owned ciphers.
+INSERT INTO favorites(user_uuid, cipher_uuid)
+SELECT user_uuid, uuid
+FROM ciphers
+WHERE favorite = 1
+  AND user_uuid IS NOT NULL;
+
 -- Drop the `favorite` column from the `ciphers` table, using the 12-step
 -- procedure from <https://www.sqlite.org/lang_altertable.html#altertabrename>.
 -- Note that some steps aren't applicable and are omitted.

--- a/migrations/sqlite/2020-08-02-025025_add_favorites_table/up.sql
+++ b/migrations/sqlite/2020-08-02-025025_add_favorites_table/up.sql
@@ -1,0 +1,64 @@
+CREATE TABLE favorites (
+  user_uuid   TEXT NOT NULL REFERENCES users(uuid),
+  cipher_uuid TEXT NOT NULL REFERENCES ciphers(uuid),
+
+  PRIMARY KEY (user_uuid, cipher_uuid)
+);
+
+-- Drop the `favorite` column from the `ciphers` table, using the 12-step
+-- procedure from <https://www.sqlite.org/lang_altertable.html#altertabrename>.
+-- Note that some steps aren't applicable and are omitted.
+
+-- 1. If foreign key constraints are enabled, disable them using PRAGMA foreign_keys=OFF.
+--
+-- Diesel runs each migration in its own transaction. `PRAGMA foreign_keys`
+-- is a no-op within a transaction, so this step must be done outside of this
+-- file, before starting the Diesel migrations.
+
+-- 2. Start a transaction.
+--
+-- Diesel already runs each migration in its own transaction.
+
+-- 4. Use CREATE TABLE to construct a new table "new_X" that is in the
+--    desired revised format of table X. Make sure that the name "new_X" does
+--    not collide with any existing table name, of course.
+
+CREATE TABLE new_ciphers(
+  uuid              TEXT     NOT NULL PRIMARY KEY,
+  created_at        DATETIME NOT NULL,
+  updated_at        DATETIME NOT NULL,
+  user_uuid         TEXT     REFERENCES users(uuid),
+  organization_uuid TEXT     REFERENCES organizations(uuid),
+  atype             INTEGER  NOT NULL,
+  name              TEXT     NOT NULL,
+  notes             TEXT,
+  fields            TEXT,
+  data              TEXT     NOT NULL,
+  password_history  TEXT,
+  deleted_at        DATETIME
+);
+
+-- 5. Transfer content from X into new_X using a statement like:
+--    INSERT INTO new_X SELECT ... FROM X.
+
+INSERT INTO new_ciphers(uuid, created_at, updated_at, user_uuid, organization_uuid, atype,
+                        name, notes, fields, data, password_history, deleted_at)
+SELECT uuid, created_at, updated_at, user_uuid, organization_uuid, atype,
+       name, notes, fields, data, password_history, deleted_at
+FROM ciphers;
+
+-- 6. Drop the old table X: DROP TABLE X.
+
+DROP TABLE ciphers;
+
+-- 7. Change the name of new_X to X using: ALTER TABLE new_X RENAME TO X.
+
+ALTER TABLE new_ciphers RENAME TO ciphers;
+
+-- 11. Commit the transaction started in step 2.
+
+-- 12. If foreign keys constraints were originally enabled, reenable them now.
+--
+-- `PRAGMA foreign_keys` is scoped to a database connection, and Diesel
+-- migrations are run in a separate database connection that is closed once
+-- the migrations finish.

--- a/src/db/schemas/mysql/schema.rs
+++ b/src/db/schemas/mysql/schema.rs
@@ -20,7 +20,6 @@ table! {
         notes -> Nullable<Text>,
         fields -> Nullable<Text>,
         data -> Text,
-        favorite -> Bool,
         password_history -> Nullable<Text>,
         deleted_at -> Nullable<Datetime>,
     }
@@ -52,6 +51,13 @@ table! {
         push_token -> Nullable<Text>,
         refresh_token -> Text,
         twofactor_remember -> Nullable<Text>,
+    }
+}
+
+table! {
+    favorites (user_uuid, cipher_uuid) {
+        user_uuid -> Text,
+        cipher_uuid -> Text,
     }
 }
 

--- a/src/db/schemas/mysql/schema.rs
+++ b/src/db/schemas/mysql/schema.rs
@@ -1,7 +1,7 @@
 table! {
     attachments (id) {
-        id -> Varchar,
-        cipher_uuid -> Varchar,
+        id -> Text,
+        cipher_uuid -> Text,
         file_name -> Text,
         file_size -> Integer,
         akey -> Nullable<Text>,
@@ -10,11 +10,11 @@ table! {
 
 table! {
     ciphers (uuid) {
-        uuid -> Varchar,
+        uuid -> Text,
         created_at -> Datetime,
         updated_at -> Datetime,
-        user_uuid -> Nullable<Varchar>,
-        organization_uuid -> Nullable<Varchar>,
+        user_uuid -> Nullable<Text>,
+        organization_uuid -> Nullable<Text>,
         atype -> Integer,
         name -> Text,
         notes -> Nullable<Text>,
@@ -28,25 +28,25 @@ table! {
 
 table! {
     ciphers_collections (cipher_uuid, collection_uuid) {
-        cipher_uuid -> Varchar,
-        collection_uuid -> Varchar,
+        cipher_uuid -> Text,
+        collection_uuid -> Text,
     }
 }
 
 table! {
     collections (uuid) {
-        uuid -> Varchar,
-        org_uuid -> Varchar,
+        uuid -> Text,
+        org_uuid -> Text,
         name -> Text,
     }
 }
 
 table! {
     devices (uuid) {
-        uuid -> Varchar,
+        uuid -> Text,
         created_at -> Datetime,
         updated_at -> Datetime,
-        user_uuid -> Varchar,
+        user_uuid -> Text,
         name -> Text,
         atype -> Integer,
         push_token -> Nullable<Text>,
@@ -57,31 +57,31 @@ table! {
 
 table! {
     folders (uuid) {
-        uuid -> Varchar,
+        uuid -> Text,
         created_at -> Datetime,
         updated_at -> Datetime,
-        user_uuid -> Varchar,
+        user_uuid -> Text,
         name -> Text,
     }
 }
 
 table! {
     folders_ciphers (cipher_uuid, folder_uuid) {
-        cipher_uuid -> Varchar,
-        folder_uuid -> Varchar,
+        cipher_uuid -> Text,
+        folder_uuid -> Text,
     }
 }
 
 table! {
     invitations (email) {
-        email -> Varchar,
+        email -> Text,
     }
 }
 
 table! {
     org_policies (uuid) {
-        uuid -> Varchar,
-        org_uuid -> Varchar,
+        uuid -> Text,
+        org_uuid -> Text,
         atype -> Integer,
         enabled -> Bool,
         data -> Text,
@@ -90,7 +90,7 @@ table! {
 
 table! {
     organizations (uuid) {
-        uuid -> Varchar,
+        uuid -> Text,
         name -> Text,
         billing_email -> Text,
     }
@@ -98,8 +98,8 @@ table! {
 
 table! {
     twofactor (uuid) {
-        uuid -> Varchar,
-        user_uuid -> Varchar,
+        uuid -> Text,
+        user_uuid -> Text,
         atype -> Integer,
         enabled -> Bool,
         data -> Text,
@@ -109,18 +109,18 @@ table! {
 
 table! {
     users (uuid) {
-        uuid -> Varchar,
+        uuid -> Text,
         created_at -> Datetime,
         updated_at -> Datetime,
         verified_at -> Nullable<Datetime>,
         last_verifying_at -> Nullable<Datetime>,
         login_verify_count -> Integer,
-        email -> Varchar,
-        email_new -> Nullable<Varchar>,
-        email_new_token -> Nullable<Varchar>,
+        email -> Text,
+        email_new -> Nullable<Text>,
+        email_new_token -> Nullable<Text>,
         name -> Text,
-        password_hash -> Blob,
-        salt -> Blob,
+        password_hash -> Binary,
+        salt -> Binary,
         password_iterations -> Integer,
         password_hint -> Nullable<Text>,
         akey -> Text,
@@ -138,8 +138,8 @@ table! {
 
 table! {
     users_collections (user_uuid, collection_uuid) {
-        user_uuid -> Varchar,
-        collection_uuid -> Varchar,
+        user_uuid -> Text,
+        collection_uuid -> Text,
         read_only -> Bool,
         hide_passwords -> Bool,
     }
@@ -147,9 +147,9 @@ table! {
 
 table! {
     users_organizations (uuid) {
-        uuid -> Varchar,
-        user_uuid -> Varchar,
-        org_uuid -> Varchar,
+        uuid -> Text,
+        user_uuid -> Text,
+        org_uuid -> Text,
         access_all -> Bool,
         akey -> Text,
         status -> Integer,

--- a/src/db/schemas/postgresql/schema.rs
+++ b/src/db/schemas/postgresql/schema.rs
@@ -20,7 +20,6 @@ table! {
         notes -> Nullable<Text>,
         fields -> Nullable<Text>,
         data -> Text,
-        favorite -> Bool,
         password_history -> Nullable<Text>,
         deleted_at -> Nullable<Timestamp>,
     }
@@ -52,6 +51,13 @@ table! {
         push_token -> Nullable<Text>,
         refresh_token -> Text,
         twofactor_remember -> Nullable<Text>,
+    }
+}
+
+table! {
+    favorites (user_uuid, cipher_uuid) {
+        user_uuid -> Text,
+        cipher_uuid -> Text,
     }
 }
 

--- a/src/db/schemas/sqlite/schema.rs
+++ b/src/db/schemas/sqlite/schema.rs
@@ -20,7 +20,6 @@ table! {
         notes -> Nullable<Text>,
         fields -> Nullable<Text>,
         data -> Text,
-        favorite -> Bool,
         password_history -> Nullable<Text>,
         deleted_at -> Nullable<Timestamp>,
     }
@@ -52,6 +51,13 @@ table! {
         push_token -> Nullable<Text>,
         refresh_token -> Text,
         twofactor_remember -> Nullable<Text>,
+    }
+}
+
+table! {
+    favorites (user_uuid, cipher_uuid) {
+        user_uuid -> Text,
+        cipher_uuid -> Text,
     }
 }
 


### PR DESCRIPTION
Currently, favorites are tracked at the cipher level. For org-owned ciphers,
this means that if one user sets it as a favorite, it automatically becomes a
favorite for all other users that the cipher has been shared with.

Fixes #885.