### PR TITLE
Add DATABASE_MAX_CONNS config setting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,6 +20,10 @@
 ## - https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 # DATABASE_URL=postgresql://user:password@host[:port]/database_name
 
+## Database max connections
+## Define the size of the connection pool used for connecting to the database.
+# DATABASE_MAX_CONNS=10
+
 ## Individual folders, these override %DATA_FOLDER%
 # RSA_KEY_FILENAME=data/rsa_key
 # ICON_CACHE_FOLDER=data/icon_cache

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,6 +222,8 @@ make_config! {
         data_folder:            String, false,  def,    "data".to_string();
         /// Database URL
         database_url:           String, false,  auto,   |c| format!("{}/{}", c.data_folder, "db.sqlite3");
+        /// Database connection pool size
+        database_max_conns:     u32,    false,  def,    10;
         /// Icon cache folder
         icon_cache_folder:      String, false,  auto,   |c| format!("{}/{}", c.data_folder, "icon_cache");
         /// Attachments folder
@@ -428,6 +430,14 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
 
     // Validate connection URL is valid and DB feature is enabled
     DbConnType::from_url(&cfg.database_url)?;
+
+    let limit = 256;
+    if cfg.database_max_conns < 1 || cfg.database_max_conns > limit {
+        err!(format!(
+            "`DATABASE_MAX_CONNS` contains an invalid value. Ensure it is between 1 and {}.",
+            limit,
+        ));
+    }
 
     let dom = cfg.domain.to_lowercase();
     if !dom.starts_with("http://") && !dom.starts_with("https://") {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -51,7 +51,10 @@ macro_rules! generate_connections {
                         {
                             paste::paste!{ [< $name _migrations >]::run_migrations()?; }
                             let manager = ConnectionManager::new(&url);
-                            let pool = Pool::builder().build(manager).map_res("Failed to create pool")?;
+                            let pool = Pool::builder()
+                                .max_size(CONFIG.database_max_conns())
+                                .build(manager)
+                                .map_res("Failed to create pool")?;
                             return Ok(Self::$name(pool));
                         }
                         #[cfg(not($name))]


### PR DESCRIPTION
Tiny change to allow the database connection pool size to be configured externally (useful for those of us deploying to databases with limited connection count allowances)