### PR TITLE
Hide ciphers from non-selected collections for org owners/admins

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -82,7 +82,7 @@ fn sync(data: Form<SyncData>, headers: Headers, conn: DbConn) -> JsonResult {
     let policies = OrgPolicy::find_by_user(&headers.user.uuid, &conn);
     let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
 
-    let ciphers = Cipher::find_by_user(&headers.user.uuid, &conn);
+    let ciphers = Cipher::find_by_user_visible(&headers.user.uuid, &conn);
     let ciphers_json: Vec<Value> = ciphers
         .iter()
         .map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn))
@@ -107,7 +107,7 @@ fn sync(data: Form<SyncData>, headers: Headers, conn: DbConn) -> JsonResult {
 
 #[get("/ciphers")]
 fn get_ciphers(headers: Headers, conn: DbConn) -> JsonResult {
-    let ciphers = Cipher::find_by_user(&headers.user.uuid, &conn);
+    let ciphers = Cipher::find_by_user_visible(&headers.user.uuid, &conn);
 
     let ciphers_json: Vec<Value> = ciphers
         .iter()

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -208,21 +208,20 @@ impl Collection {
         match UserOrganization::find_by_user_and_org(&user_uuid, &self.org_uuid, &conn) {
             None => false, // Not in Org
             Some(user_org) => {
-                if user_org.access_all {
-                    true
-                } else {
-                    db_run! { conn: {
-                        users_collections::table
-                            .inner_join(collections::table)
-                            .filter(users_collections::collection_uuid.eq(&self.uuid))
-                            .filter(users_collections::user_uuid.eq(&user_uuid))
-                            .filter(users_collections::read_only.eq(false))
-                            .select(collections::all_columns)
-                            .first::<CollectionDb>(conn)
-                            .ok()
-                            .is_some() // Read only or no access to collection
-                    }}
+                if user_org.has_full_access() {
+                    return true;
                 }
+
+                db_run! { conn: {
+                    users_collections::table
+                        .filter(users_collections::collection_uuid.eq(&self.uuid))
+                        .filter(users_collections::user_uuid.eq(user_uuid))
+                        .filter(users_collections::read_only.eq(false))
+                        .count()
+                        .first::<i64>(conn)
+                        .ok()
+                        .unwrap_or(0) != 0
+                }}
             }
         }
     }


### PR DESCRIPTION
If org owners/admins set their org access to only include selected
collections, then ciphers from non-selected collections shouldn't
appear in "My Vault". This matches the upstream behavior.

Fixes #1123.