### PR TITLE
Format some common Lettre errors a bit simpler

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -79,7 +79,7 @@ make_error! {
     RegexError(RegexErr): _has_source, _api_error,
     YubiError(YubiErr):   _has_source, _api_error,
 
-    LetreError(LettreErr):    _has_source, _api_error,
+    LettreError(LettreErr):   _has_source, _api_error,
     AddressError(AddrErr):    _has_source, _api_error,
     SmtpError(SmtpErr):       _has_source, _api_error,
     FromStrError(FromStrErr): _has_source, _api_error,


### PR DESCRIPTION
Currently when for example using the admin interface to send out a test e-mail just
returns `SmtpError`. This is not very helpful. What i have done.

- Match some common Lettre errors to return the error message.
- Other errors will just be passed on as before.

Some small other changes:
- Fixed a clippy warning about using clone().
- Fixed a typo where Lettere was spelled with one t.