### PR TITLE
Add bitwarden_rs helm-chart

### DIFF
--- a/.github/ct_test_config.yaml
+++ b/.github/ct_test_config.yaml
@@ -1,0 +1,3 @@
+helm-extra-args: --timeout 600s
+charts:
+  - contrib/helm-chart/

--- a/.github/workflows/bitwarden_rs.yml
+++ b/.github/workflows/bitwarden_rs.yml
@@ -1,9 +1,10 @@
-name: Workflow
+name: Test&Release Bitwarden_rs
 
 on:
   push:
     paths-ignore:
       - "**.md"
+      - 'contrib/helm-chart/**'
   #pull_request:
   #  paths-ignore:
   #    - "**.md"

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -1,0 +1,42 @@
+name: Test&Release HelmChart
+on:
+  push:
+    paths:
+      - 'contrib/helm-chart/**'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - 'contrib/helm-chart/**'
+      - '.github/workflows/**'
+jobs:
+  test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fetch history
+        run: |
+          git fetch --prune --unshallow;
+          echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        if: "! contains(env.commitmsg, '[skip lint]')"
+        with:
+          command: lint
+          config: .github/ct_test_config.yaml
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: "! contains(env.commitmsg, '[skip install]')"
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0
+        if: "! contains(env.commitmsg, '[skip install]')"
+        with:
+          command: install
+          config: .github/ct_test_config.yaml
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        if: "contains(env.commitmsg, '[release chart]') && github.event_name == 'push' && github.ref == 'refs/heads/master'"
+        with:
+          charts_dir: contrib/
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/contrib/helm-chart/.helmignore
+++ b/contrib/helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib/helm-chart/Chart.yaml
+++ b/contrib/helm-chart/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: bitwardenrs
+description: Unofficial Bitwarden compatible server written in Rust
+type: application
+version: 0.1.5
+appVersion: 1.16.3
+icon: https://upload.wikimedia.org/wikipedia/commons/0/03/Bitwarden_Logo.png
+home: https://github.com/dani-garcia/bitwarden_rs
+keywords:
+  - bitwarden
+  - bitwarden_rs
+  - password
+sources:
+  - https://github.com/dani-garcia/bitwarden_rs
+maintainers:
+  - name: dani-garcia

--- a/contrib/helm-chart/LICENSE
+++ b/contrib/helm-chart/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Silvio Gissi <silvio@gissilabs.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/contrib/helm-chart/README.md
+++ b/contrib/helm-chart/README.md
@@ -1,0 +1,144 @@
+# Gissilabs Helm Charts
+
+## bitwarden_rs
+
+Bitwarden_rs is an unofficial Bitwarden compatible server written in Rust. For more information, check the project on Github: <https://github.com/dani-garcia/bitwarden_rs>
+
+## Helm Chart
+
+The default installation will deploy one bitwarden_rs instance using a SQLite database without persistence. All data will be lost if the pod is deleted.
+
+```bash
+helm repo add bitwardenrs https://dani-garcia.github.io/bitwarden_rs/
+helm repo update
+helm install mybitwardenrs bitwardenrs/bitwardenrs
+```
+
+See options below to customize the deployment.
+
+## **Database**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+database.type | Backend database type | sqlite, mysql or postgresql | sqlite
+database.wal | Enable SQLite Write-Ahead-Log, ignored for external databases | true / false | true
+database.url | URL of external database (MySQL/PostgreSQL) | \[mysql\|postgresql\]://user:pass@host:port | Empty
+database.existingSecret | Use existing secret for database URL, key 'database-url' | Secret name  | Not defined
+
+## **Main application**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+bitwardenrs.domain | Bitwarden URL. Mandatory for invitations over email | http\[s\]://hostname | Not defined
+bitwardenrs.allowSignups | Allow any user to sign-up. [More information](https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-registration-of-new-users) | true / false | true
+bitwardenrs.signupDomains | Whitelist domains allowed to sign-up. 'allowSignups' is ignored if set | domain1,domain2 | Not defined
+bitwardenrs.verifySignup | Verify e-mail before login is enabled. SMTP must be enabled | true / false | false
+bitwardenrs.allowInvitation | Allow invited users to sign-up even feature is disabled. [More information](https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-invitations) | true / false | true
+bitwardenrs.defaultInviteName | Default organization name in invitation e-mails that are not coming from a specific organization. | Text | Bitwarden_RS
+bitwardenrs.showPasswordHint | Show password hints. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Password-hint-display) | true / false | true
+bitwardenrs.enableWebsockets | Enable Websockets for notification. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-WebSocket-notifications). If using Ingress controllers, "notifications/hub" URL is redirected to websocket port | true / false | true
+bitwardenrs.enableWebVault | Enable Web Vault static site. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Disabling-or-overriding-the-Vault-interface-hosting). | true / false | true
+bitwardenrs.orgCreationUsers | Restrict creation of orgs. | 'all', 'none' or a comma-separated list of users. | all
+bitwardenrs.extraEnv | Pass extra environment variables | Map | Not defined
+bitwardenrs.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/bitwarden_rs/wiki/Logging) | File path | Empty
+bitwardenrs.log.level | Change log level | trace, debug, info, warn, error or off | Empty
+bitwardenrs.log.timeFormat | Log timestamp | Rust chrono [format](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html). | Time in milliseconds | Empty
+
+## **Application Features**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+bitwardenrs.admin.enabled | Enable admin portal. Change settings in the portal will overwrite chart options. | true / false | false
+bitwardenrs.admin.disableAdminToken | Disabling the admin token will make the admin portal accessible to anyone, use carefully. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-admin-token) | true / false | false
+bitwardenrs.admin.token | Token for admin login, will be generated if not defined. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-admin-page) | Text | Auto-generated
+bitwardenrs.admin.existingSecret | Use existing secret for the admin token. Key is 'admin-token' | Secret name | Not defined
+|||
+bitwardenrs.smtp.enabled | Enable SMTP | true / false | false
+bitwardenrs.smtp.host | SMTP hostname **required** | Hostname | Empty
+bitwardenrs.smtp.from | SMTP sender e-mail address **required** | E-mail | Empty
+bitwardenrs.smtp.fromName | SMTP sender name | Text | Bitwarden_RS
+bitwardenrs.smtp.ssl | Enable SSL connection | true / false | true
+bitwardenrs.smtp.port | SMTP TCP port | Number | SSL Enabled: 587. SSL Disabled: 25
+bitwardenrs.smtp.authMechanism | SMTP Authentication Mechanisms | Comma-separated list: 'Plain', 'Login', 'Xoauth2' | Plain
+bitwardenrs.smtp.heloName | Hostname to be sent for SMTP HELO | Text | Pod name
+bitwardenrs.smtp.user | SMTP username | Text | Not defined
+bitwardenrs.smtp.password | SMTP password. Required is user is specified | Text | Not defined
+bitwardenrs.smtp.existingSecret | Use existing secret for SMTP authentication. Keys are 'smtp-user' and 'smtp-password' | Secret name | Not defined
+|||
+bitwardenrs.yubico.enabled | Enable Yubikey support | true / false | false
+bitwardenrs.yubico.server | Yubico server | Hostname | YubiCloud
+bitwardenrs.yubico.clientId | Yubico ID | Text | Not defined
+bitwardenrs.yubico.secretKey | Yubico Secret Key | Text | Not defined
+bitwardenrs.yubico.existingSecret | Use existing secret for ID and Secret. Keys are 'yubico-client-id' and 'yubico-secret-key' | Secret name | Not defined
+
+## **Network**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+service.type | Service Type. [More Information](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | Type | ClusterIP
+service.httpPort | Service port for HTTP server | Number | 80
+service.websocketPort | Service port for Websocket server, if enabled | Number | 3012
+service.externalTrafficPolicy | External Traffic Policy. [More Information](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) | Local / Cluster| Cluster
+service.loadBalancerIP | Manually select IP when type is LoadBalancer | IP address | Not defined
+service.nodePorts.http | Manually select node port for http | Number | Empty
+service.nodePorts.websocket | Manually select node port for websocker, if enabled | Number | Empty
+|||
+ingress.enabled | Enable Ingress | true / false | false
+ingress.host | Ingress hostname **required** | Hostname | Empty
+ingress.annotations | Ingress annotations | Map | Empty
+ingress.tls | Ingress TLS options | Array of Maps | Empty
+|||
+ingressRoute.enabled | Enable Traefik IngressRoute CRD | true / false | false
+ingressRoute.host | Ingress route hostname **required** | Hostname | Empty
+ingressRoute.middlewares | Enable middlewares | Map | Empty
+ingressRoute.entrypoints | List of Traefik endpoints | Array of Text | \[websecure\]
+ingressRoute.tls | Ingress route TLS options | Map | Empty
+
+## **Storage**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+persistence.enabled | Create persistent volume (PVC). Holds attachments, icon cache and, if used, the SQLite database | true / false | false
+persistence.size | Size of volume | Size | 1Gi
+persistence.accessMode | Volume access mode | Text | ReadWriteOnce
+persistence.storageClass | Storage Class | Text | Not defined. Use "-" for default class
+persistence.existingClaim | Use existing PVC | Name of PVC | Not defined
+
+## **Image**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+image.tag | Docker image tag | Text | Chart appVersion (Chart.yaml)
+image.sqliteRepository | Docker image for SQLite | Text | bitwardenrs/server
+image.mysqlRepository | Docker image for MySQL | Text | bitwardenrs/server-mysql
+image.postgresqlRepository | Docker image for PostgreSQL | Text | bitwardenrs/server-postgresql
+imagePullSecrets | Image pull secrets | Array | Empty
+
+## **General Kubernetes/Helm**
+
+Option | Description | Format | Default
+------ | ----------- | ------ | -------
+strategy | Deployment Strategy options | sub-tree | Empty
+replicaCount | Number of pod replicas | Number | 1
+nameOverride | Name override | Text | Empty
+fullnameOverride | Full name override | Text | Empty
+serviceAccount.create | Create Service Account | true / false | false
+serviceAccount.annotations | Annotations service account | Map | Empty
+serviceAccount.name | Service Account name | Text | Generated from template
+podAnnotations | Pod Annotations | Map | Empty
+podSecurityContext | Pod-level Security Context | Map | {fsGroup:65534}
+securityContext | Container-level Security Context | Map | {runAsUser:65534, runAsGroup:65534}
+resources | Deployment Resources | Map | Empty
+nodeSelector | Node selector | Map | Empty
+tolerations | Tolerations | Array | Empty
+affinity | Affinity | Map | Empty
+
+
+## Releasing new chart versions:
+
+Chart versions are released seperately from Bitwarden_rs.
+Releases should always contain a new version number and can be triggered by adding `[release chart]` to a commit message pushed to master.
+(release is triggered on push/merge, not PR)
+
+### License
+This chart is licensed under Apachev2.

--- a/contrib/helm-chart/templates/NOTES.txt
+++ b/contrib/helm-chart/templates/NOTES.txt
@@ -1,0 +1,25 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}/
+{{- else if .Values.ingressRoute.enabled }}
+  http{{ if $.Values.ingressRoute.tls }}s{{ end }}://{{ .Values.ingressRoute.host }}/
+{{- else }}
+  {{- if eq .Values.bitwardenrs.enableWebsockets true }}
+  NOTE: the websocket listens on a different port and might not work unless /notifications/hub is redirected externally.
+  
+  {{- end }}
+  {{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "bitwardenrs.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "bitwardenrs.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "bitwardenrs.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.httpPort }}
+  {{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "bitwardenrs.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:8080
+{{- end }}
+{{- end }}

--- a/contrib/helm-chart/templates/_helpers.tpl
+++ b/contrib/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bitwardenrs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bitwardenrs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bitwardenrs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bitwardenrs.labels" -}}
+helm.sh/chart: {{ include "bitwardenrs.chart" . }}
+{{ include "bitwardenrs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bitwardenrs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bitwardenrs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bitwardenrs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bitwardenrs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Ensure valid DB type is select, defaults to SQLite
+*/}}
+{{- define "bitwardenrs.image" -}}
+{{- if eq .Values.database.type "postgresql" }}
+{{- .Values.image.postgresqlRepository -}}
+{{- else if eq .Values.database.type "mysql" }}
+{{- .Values.image.mysqlRepository -}}
+{{- else if eq .Values.database.type "sqlite" }}
+{{- .Values.image.sqliteRepository -}}
+{{- else }}
+{{- required "Invalid database type" nil }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Ensure log type is valid
+*/}}
+{{- define "bitwardenrs.logLevelValid" -}}
+{{- if not (or (eq .Values.bitwardenrs.log.level "trace") (eq .Values.bitwardenrs.log.level "debug") (eq .Values.bitwardenrs.log.level "info") (eq .Values.bitwardenrs.log.level "warn") (eq .Values.bitwardenrs.log.level "error") (eq .Values.bitwardenrs.log.level "off")) }}
+{{- required "Invalid log level" nil }}
+{{- end }}
+{{- end }}

--- a/contrib/helm-chart/templates/deployment.yaml
+++ b/contrib/helm-chart/templates/deployment.yaml
@@ -1,0 +1,210 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bitwardenrs.fullname" . }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "bitwardenrs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "bitwardenrs.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bitwardenrs.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ include "bitwardenrs.image" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ROCKET_PORT
+              value: "8080"
+            - name: SIGNUPS_ALLOWED
+              value: {{ .Values.bitwardenrs.allowSignups | quote }}
+            {{- if .Values.bitwardenrs.signupDomains }}
+            - name: SIGNUPS_DOMAINS_WHITELIST
+              value: {{ join "," .Values.bitwardenrs.signupDomains | quote }}
+            {{- end }}
+            {{- if and (eq .Values.bitwardenrs.verifySignup true) (eq .Values.bitwardenrs.smtp.enabled false) }}{{ required "Signup verification requires SMTP to be enabled" nil}}{{end}}
+            - name: SIGNUPS_VERIFY
+              value: {{ .Values.bitwardenrs.verifySignup | quote }}
+            - name: INVITATIONS_ALLOWED
+              value: {{ .Values.bitwardenrs.allowInvitation | quote }}
+            {{- if .Values.bitwardenrs.defaultInviteName }}
+            - name: INVITATION_ORG_NAME
+              value: {{ .Values.bitwardenrs.defaultInviteName | quote }}
+            {{- end }}
+            - name: SHOW_PASSWORD_HINT
+              value: {{ .Values.bitwardenrs.showPasswordHint | quote }}
+            - name: WEBSOCKET_ENABLED
+              value: {{ .Values.bitwardenrs.enableWebsockets | quote }}
+            - name: WEB_VAULT_ENABLED
+              value: {{ .Values.bitwardenrs.enableWebVault | quote }}
+            - name: ORG_CREATION_USERS
+              value: {{ .Values.bitwardenrs.orgCreationUsers | quote }}
+            {{- if .Values.bitwardenrs.extraEnv }}
+            {{- range $key, $val := .Values.bitwardenrs.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.database.type "sqlite" }}
+            - name: ENABLE_DB_WAL
+              value: {{ .Values.database.wal | quote }}
+            {{- else }}
+            - name: ENABLE_DB_WAL
+              value: "false"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.database.existingSecret }}{{ .Values.database.existingSecret }}{{else}}{{ include "bitwardenrs.fullname" . }}{{end}}
+                  key: database-url
+            {{- end }}
+            {{- if .Values.bitwardenrs.domain }}
+            - name: DOMAIN
+              value: {{ .Values.bitwardenrs.domain | quote }}
+            {{- end }}
+            {{- if eq .Values.bitwardenrs.admin.enabled true }}
+            {{- if eq .Values.bitwardenrs.admin.disableAdminToken true }}
+            - name: DISABLE_ADMIN_TOKEN
+              value: "true"
+            {{- else }}
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bitwardenrs.admin.existingSecret | default (include "bitwardenrs.fullname" .) }}
+                  key: admin-token
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.bitwardenrs.smtp.enabled true }}
+            - name: SMTP_HOST
+              value: {{ required "SMTP host is required to enable SMTP" .Values.bitwardenrs.smtp.host | quote }}
+            - name: SMTP_FROM
+              value: {{ required "SMTP sender address ('from') is required to enable SMTP" .Values.bitwardenrs.smtp.from | quote }}
+            {{- if .Values.bitwardenrs.smtp.fromName }}
+            - name: SMTP_FROM_NAME
+              value: {{ .Values.bitwardenrs.smtp.fromName | quote }}
+            {{- end }}
+            {{- if .Values.bitwardenrs.smtp.ssl }}
+            - name: SMTP_SSL
+              value: {{ .Values.bitwardenrs.smtp.ssl | quote }}
+            {{- end }}
+            {{- if .Values.bitwardenrs.smtp.port }}
+            - name: SMTP_PORT
+              value: {{ .Values.bitwardenrs.smtp.port | quote }}
+            {{- end }}
+            {{- if .Values.bitwardenrs.smtp.authMechanism }}
+            - name: SMTP_AUTH_MECHANISM
+              value: {{ .Values.bitwardenrs.smtp.authMechanism | quote }}
+            {{- end }}
+            {{- if .Values.bitwardenrs.smtp.heloName }}
+            - name: HELO_NAME
+              value: {{ .Values.bitwardenrs.smtp.heloName | quote }}
+            {{- end }}
+            {{- if or .Values.bitwardenrs.smtp.existingSecret .Values.bitwardenrs.smtp.user }}
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bitwardenrs.smtp.existingSecret | default (include "bitwardenrs.fullname" .) }}
+                  key: smtp-user
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bitwardenrs.smtp.existingSecret | default (include "bitwardenrs.fullname" .) }}
+                  key: smtp-password
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.bitwardenrs.yubico.enabled true }}
+            {{- if .Values.bitwardenrs.yubico.server }}
+            - name: YUBICO_SERVER
+              value: {{ .Values.bitwardenrs.yubico.server | quote }}
+            {{- end }}  
+            - name: YUBICO_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bitwardenrs.yubico.existingSecret | default (include "bitwardenrs.fullname" .) }}
+                  key: yubico-client-id
+            - name: YUBICO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bitwardenrs.yubico.existingSecret | default (include "bitwardenrs.fullname" .) }}
+                  key: yubico-secret-key
+            {{- end }}
+            {{- if .Values.bitwardenrs.log.file }}
+            - name: LOG_FILE
+              value: {{ .Values.bitwardenrs.log.file | quote }}
+            {{- end }}
+            {{- if or .Values.bitwardenrs.log.level .Values.bitwardenrs.log.timeFormat }}
+            - name: EXTENDED_LOGGING
+              value: "true"
+            {{- end }}
+            {{- if .Values.bitwardenrs.log.level }}
+            {{- include "bitwardenrs.logLevelValid" . }}
+            - name: LOG_LEVEL
+              value: {{ .Values.bitwardenrs.log.level | quote }}
+            {{- end }}
+            {{- if .Values.bitwardenrs.log.timeFormat }}
+            - name: LOG_TIMESTAMP_FORMAT
+              value: {{ .Values.bitwardenrs.log.timeFormat | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.bitwardenrs.enableWebsockets }}
+            - name: websocket
+              containerPort: 3012
+              protocol: TCP
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          volumeMounts:
+          - name: {{ include "bitwardenrs.fullname" . }}
+            mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: {{ include "bitwardenrs.fullname" . }}
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim | quote }}{{- else }}{{ include "bitwardenrs.fullname" . }}{{- end }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm-chart/templates/ingress.yaml
+++ b/contrib/helm-chart/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "bitwardenrs.fullname" . -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ required "Host required for ingress" .Values.ingress.host | quote }}
+      http:
+        paths:
+          {{- if .Values.bitwardenrs.enableWebsockets }}
+          - path: "/notifications/hub"
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.service.websocketPort }}
+          {{- end }}
+          - path: "/"
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.service.httpPort }}
+{{- end }}

--- a/contrib/helm-chart/templates/ingressroute.yaml
+++ b/contrib/helm-chart/templates/ingressroute.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingressRoute.enabled -}}
+{{- $fullName := include "bitwardenrs.fullname" . -}}
+{{- $host := (required "Host required for IngressRoute" .Values.ingressRoute.host ) -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+  {{- range .Values.ingressRoute.entrypoints }}
+    - {{ . | quote }}
+  {{- end }}
+  routes:
+  {{- if .Values.bitwardenrs.enableWebsockets }}
+  - match: Host(`{{ $host }}`) && PathPrefix(`/notifications/hub`)
+    kind: Rule
+    {{- if .Values.ingressRoute.middlewares }}
+    middlewares:
+      {{- toYaml .Values.ingressRoute.middlewares | nindent 6 }}
+    {{- end }}
+    services:
+    - name: {{ $fullName }} 
+      port: {{ .Values.service.websocketPort }}
+  {{- end }}
+  - match: Host(`{{ $host }}`)
+    kind: Rule
+    {{- if .Values.ingressRoute.middlewares }}
+    middlewares:
+      {{- toYaml .Values.ingressRoute.middlewares | nindent 6 }}
+    {{- end }}
+    services:
+    - name: {{ $fullName }}
+      port: {{ .Values.service.httpPort }}
+  {{- if .Values.ingressRoute.tls }}
+  tls:
+    {{- toYaml .Values.ingressRoute.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm-chart/templates/pvc.yaml
+++ b/contrib/helm-chart/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "bitwardenrs.fullname" . }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end -}}

--- a/contrib/helm-chart/templates/secret.yaml
+++ b/contrib/helm-chart/templates/secret.yaml
@@ -1,0 +1,43 @@
+{{- $adminToken := "" }}
+{{- if and (eq .Values.bitwardenrs.admin.enabled true) (not .Values.bitwardenrs.admin.existingSecret) }}
+{{- $adminToken = .Values.bitwardenrs.admin.token | default (randAlphaNum 48) | b64enc | quote }}
+{{- end -}}
+
+{{- $databaseUrl := "" }}
+{{- if and (ne .Values.database.type "sqlite") (not .Values.database.existingSecret) }}
+{{- $databaseUrl = required "External databases need either URL or existing secret" .Values.database.url | b64enc | quote }}
+{{- end -}}
+
+{{- $smtpUser := "" }}
+{{- if and (eq .Values.bitwardenrs.smtp.enabled true ) (not .Values.bitwardenrs.smtp.exitingSecret) (.Values.bitwardenrs.smtp.user) }}
+{{- $smtpUser = .Values.bitwardenrs.smtp.user | b64enc | quote }}
+{{- end -}}
+
+{{- $yubicoClientId := "" }}
+{{- if and (eq .Values.bitwardenrs.yubico.enabled true ) (not .Values.bitwardenrs.yubico.exitingSecret) }}
+{{- $yubicoClientId = required "Yubico Client ID required" .Values.bitwardenrs.yubico.clientId | toString | b64enc | quote }}
+{{- end -}}
+
+{{- if or (ne $adminToken "") (ne $databaseUrl "") (ne $smtpUser "" ) (ne $yubicoClientId "") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bitwardenrs.fullname" . }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+data:
+  {{- if ne $adminToken "" }}
+  admin-token: {{ $adminToken }}
+  {{- end }}
+  {{- if ne $databaseUrl "" }}
+  database-url: {{ $databaseUrl }}
+  {{- end }}
+  {{- if ne $smtpUser "" }}
+  smtp-user: {{ $smtpUser }}
+  smtp-password: {{ required "Must specify SMTP password" .Values.bitwardenrs.smtp.password | b64enc | quote }}
+  {{- end }}
+  {{- if ne $yubicoClientId "" }}
+  yubico-client-id: {{ $yubicoClientId }}
+  yubico-secret-key: {{ required "Yubico Secret Key required" .Values.bitwardenrs.yubico.secretKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm-chart/templates/service.yaml
+++ b/contrib/helm-chart/templates/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bitwardenrs.fullname" . }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- end }}
+    {{- if .Values.bitwardenrs.enableWebsockets }}
+    - name: websocket
+      port: {{ .Values.service.websocketPort }}
+      targetPort: websocket
+      protocol: TCP
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.websocket)))}}
+      nodePort: {{ .Values.service.nodePorts.websocket }}
+      {{- end }}
+    {{- end }}
+  selector:
+    {{- include "bitwardenrs.selectorLabels" . | nindent 4 }}

--- a/contrib/helm-chart/templates/serviceaccount.yaml
+++ b/contrib/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bitwardenrs.serviceAccountName" . }}
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm-chart/templates/tests/test-connection.yaml
+++ b/contrib/helm-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "bitwardenrs.fullname" . }}-test-connection"
+  labels:
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "bitwardenrs.fullname" . }}:{{ .Values.service.httpPort }}']
+  restartPolicy: Never

--- a/contrib/helm-chart/values.yaml
+++ b/contrib/helm-chart/values.yaml
@@ -1,0 +1,190 @@
+# Default values for bitwarden_rs.
+
+database:
+  # Database type, must be one of: 'sqlite', 'mysql' or 'postgresql'.
+  type: sqlite
+  # Enable DB Write-Ahead-Log for SQLite, disabled for other databases. https://github.com/dani-garcia/bitwarden_rs/wiki/Running-without-WAL-enabled
+  wal: true
+  ## URL for external databases (mysql://user:pass@host:port or postgresql://user:pass@host:port).
+  # url: ""
+  ## Use existing secret for database URL, key 'database-url'.
+  # existingSecret:
+
+# Set Bitwarden_rs application variables
+bitwardenrs:
+  ## Set Bitwarden URL, mandatory for invitations over email. Recommended if using a reverse proxy / ingress. Format is https://name or http://name
+  # domain:
+  # Allow any user to sign-up: https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-registration-of-new-users
+  allowSignups: true
+  ## Whitelist domains allowed to sign-up. 'allowSignups' is ignored if set.
+  # signupDomains:
+  #  - domain.tld
+  # Verify e-mail before login is enabled. SMTP must be enabled.
+  verifySignup: false
+  # Allow invited users to sign-up even feature is disabled: https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-invitations
+  allowInvitation: true
+  # Show password hints: https://github.com/dani-garcia/bitwarden_rs/wiki/Password-hint-display
+  ## Default organization name in invitation e-mails that are not coming from a specific organization.
+  # defaultInviteName: ""
+  showPasswordHint: true
+  # Enable Websockets for notification. https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-WebSocket-notifications
+  # Redirect HTTP path "/notifications/hub" to port 3012. Ingress/IngressRoute controllers are automatically configured.
+  enableWebsockets: true
+  # Enable Web Vault (static content). https://github.com/dani-garcia/bitwarden_rs/wiki/Disabling-or-overriding-the-Vault-interface-hosting
+  enableWebVault: true
+  # Restrict creation of orgs. Options are: 'all', 'none' or a comma-separated list of users.
+  orgCreationUsers: all
+  ## Map of custom environment variables. Use carefully.
+  # extraEnv:
+  #  IP_HEADER=CF-Connecting-IP
+
+  admin:
+    # Enable admin portal.
+    enabled: false
+    # Disabling the admin token will make the admin portal accessible to anyone, use carefully: https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-admin-token
+    disableAdminToken: false
+    ## Token for admin login, will be generated if not defined. https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-admin-page
+    # token:
+    ## Use existing secret for the admin token. Key is 'admin-token'.
+    # existingSecret:
+
+  # Enable SMTP. https://github.com/dani-garcia/bitwarden_rs/wiki/SMTP-configuration
+  smtp:
+    enabled: false
+    # SMTP hostname, required if SMTP is enabled.
+    host: ""
+    # SMTP sender e-mail address, required if SMTP is enabled.
+    from: ""
+    ## SMTP sender name, defaults to 'Bitwarden_RS'.
+    # fromName: ""
+    ## Enable SSL connection.
+    # ssl: true
+    ## SMTP port. Defaults to 25 without SSL, 587 with SSL.
+    # port: 587
+    # SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.
+    # authMechanism: Plain
+    # Hostname to be sent for SMTP HELO. Defaults to pod name.
+    # heloName: ""
+    ## SMTP username.
+    # user: ""
+    ## SMTP password. Required is user is specified, ignored if no user provided.
+    # password: ""
+    ## Use existing secret for SMTP authentication. Keys are 'smtp-user' and 'smtp-password'.
+    # existingSecret:
+
+  ## Enable Yubico OPT authentication. https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-Yubikey-OTP-authentication
+  yubico:
+    enabled: false
+    ## Yubico server. Defaults to YubiCloud.
+    # server:
+    ## Yubico ID and Secret Key.
+    # clientId:
+    # secretKey:
+    ## Use existing secret for Yubico. Keys are 'yubico-client-id' and 'yubico-secret-key'.
+    # existingSecret:
+
+  ## Logging options. https://github.com/dani-garcia/bitwarden_rs/wiki/Logging
+  log:
+    # Log to file.
+    file: ""
+    # Log level. Options are "trace", "debug", "info", "warn", "error" or "off".
+    level: ""
+    ## Log timestamp format. See https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html. Defaults to time in milliseconds.
+    # timeFormat: ""
+
+service:
+  type: ClusterIP
+  httpPort: 80
+  websocketPort: 3012
+  externalTrafficPolicy: Cluster
+  # loadBalancerIP:
+  nodePorts:
+    # Choose NodePorts manually
+    http: ""
+    websocket: ""
+
+# Kubernetes Ingress
+ingress:
+  enabled: false
+  host: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls: []
+  #  - secretName: bitwardenrs-tls
+  #    hosts:
+  #      - bitwardenrs.local
+
+# Traefik IngressRoute CRD
+ingressRoute:
+  enabled: false
+  # Mandatory to enable IngressRoute
+  host: ""
+  entrypoints:
+    - websecure
+  ## Enable Traefik middlewares
+  middlewares: {}
+  #  - name: my_middleware
+  #    namespace: default
+  tls: {}
+    # certResolver: letsencrypt
+
+persistence:
+  enabled: false
+  size: 1Gi
+  accessMode: ReadWriteOnce
+  ## Persistent Volume storage class
+  # storageClass: "-"
+  ## Use existing Persistent Volume Claim
+  # existingClaim:
+
+image:
+  pullPolicy: IfNotPresent
+  tag: ""
+  sqliteRepository: bitwardenrs/server
+  mysqlRepository: bitwardenrs/server-mysql
+  postgresqlRepository: bitwardenrs/server-postgresql
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 65534
+
+securityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
+
+strategy: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Due to much community request:
A Helm-Chart (based on the work from GissiLabs), that includes all possible options for bitwarden_rs.

To be sure it doesn't need too much babysitting: it has it's own CI already setup and ready to go.
CI tests both pushes and pullrequests. It does both a Lint test and actual install test.

Releases for the charts would be on every commit pushed to master, with [release chart] in the title.
(this prevents accidental releases overwriting the current version and such.)

Future TODO's:
- Add a chart-version check to the CI and update if chart version is updated

**Requirements:**
Needs github pages to be setup and linked to a branch called gh-pages. (before being merged)
No actual website will be published, just a webspot to serve the packaged helmcharts.

**TLDR:**
- Adds a "contrib" directory for community contributions (that are not directly integrated into bitwarden_rs)
- Adds a helm-chart for the project
- Adds Test and Releasing CI for the helm chart
- Some cleanup

Co-authored-by: gissilabs
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>