### PR TITLE
Add `vendored_openssl` feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.11.0+1.1.1h"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1570,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ enable_syslog = []
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]
 postgresql = ["diesel/postgres", "diesel_migrations/postgres"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite", "libsqlite3-sys"]
+# Enable to use a vendored and statically linked openssl
+vendored_openssl = ["openssl/vendored"]
 
 # Enable unstable features, requires nightly
 # Currently only used to enable rusts official ip support


### PR DESCRIPTION
This feature enables the `vendored` feature from the `openssl` crate and build a statically linked version of openssl.

With this feature, I am able to build a fully static binary with [cross](https://github.com/rust-embedded/cross):
```
cross +nightly build --target x86_64-unknown-linux-musl --features "vendored_openssl sqlite" --release
```