### PR TITLE
Fixed building mysql, postgresql and sqlite3 for arm

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -35,11 +35,11 @@
 ####################### VAULT BUILD IMAGE  #######################
 {% set vault_image_hash = "sha256:e40228f94cead5e50af6575fb39850a002dad146dab6836e5da5663e6d214303" %}
 {% raw %}
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -54,13 +54,9 @@ FROM {{ build_stage_base_image }} as build
 # Alpine only works on SQlite
 ARG DB=sqlite
 
-{% elif "amd64" in target_file %}
-# AMD64 supports all
-ARG DB=sqlite,mysql,postgresql
-
 {% else %}
-# ARM only supports SQLite for now
-ARG DB=sqlite
+# Debian-based builds support multidb
+ARG DB=sqlite,mysql,postgresql
 
 {% endif %}
 # Build time options to avoid dpkg warnings and help with reproducible builds.
@@ -75,6 +71,7 @@ ENV RUSTFLAGS='-C link-arg=-s'
 
 {% elif "arm" in target_file %}
 # Install required build libs for {{ package_arch_name }} architecture.
+# To compile both mysql and postgresql we need some extra packages for both host arch and target arch
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture {{ package_arch_name }} \
@@ -82,7 +79,11 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev{{ package_arch_prefix }} \
-        libc6-dev{{ package_arch_prefix }}
+        libc6-dev{{ package_arch_prefix }} \
+        libpq5{{ package_arch_prefix }} \
+        libpq-dev \
+        libmariadb-dev{{ package_arch_prefix }} \
+        libmariadb-dev-compat{{ package_arch_prefix }}
 
 {% endif -%}
 {% if "arm64v8" in target_file %}
@@ -92,7 +93,8 @@ RUN apt-get update \
         gcc-aarch64-linux-gnu \
     && mkdir -p ~/.cargo \
     && echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config \
-    && echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config
+    && echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/aarch64-linux-gnu"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -103,7 +105,8 @@ RUN apt-get update \
         gcc-arm-linux-gnueabi \
     && mkdir -p ~/.cargo \
     && echo '[target.arm-unknown-linux-gnueabi]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabi-gcc"' >> ~/.cargo/config
+    && echo 'linker = "arm-linux-gnueabi-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/arm-linux-gnueabi"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -114,7 +117,8 @@ RUN apt-get update \
         gcc-arm-linux-gnueabihf \
     && mkdir -p ~/.cargo \
     && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/arm-linux-gnueabihf"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -138,19 +142,43 @@ COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
 {% if "alpine" not in target_file %}
+{%   if "arm" in target_file %}
+# NOTE: This should be the last apt-get/dpkg for this stage, since after this it will fail because of broken dependencies.
+# For Diesel-RS migrations_macros to compile with MySQL/MariaDB we need to do some magic.
+# We at least need libmariadb3:amd64 installed for the x86_64 version of libmariadb.so (client)
+# We also need the libmariadb-dev-compat:amd64 but it can not be installed together with the {{ package_arch_prefix }} version.
+# What we can do is a force install, because nothing important is overlapping each other.
+RUN apt-get install -y libmariadb3:amd64 && \
+    mkdir -pv /tmp/dpkg && \
+    cd /tmp/dpkg && \
+    apt-get download libmariadb-dev-compat:amd64 && \
+    dpkg --force-all -i *.deb && \
+    rm -rf /tmp/dpkg
+
+# For Diesel-RS migrations_macros to compile with PostgreSQL we need to do some magic.
+# The libpq5{{ package_arch_prefix }} package seems to not provide a symlink to libpq.so.5 with the name libpq.so.
+# This is only provided by the libpq-dev package which can't be installed for both arch at the same time.
+# Without this specific file the ld command will fail and compilation fails with it.
+{%   endif -%}
 {%   if "arm64v8" in target_file %}
+RUN ln -sfnr /usr/lib/aarch64-linux-gnu/libpq.so.5 /usr/lib/aarch64-linux-gnu/libpq.so
+
 ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
 ENV OPENSSL_LIB_DIR="/usr/lib/aarch64-linux-gnu"
 RUN rustup target add aarch64-unknown-linux-gnu
 {%   elif "arm32v6" in target_file %}
+RUN ln -sfnr /usr/lib/arm-linux-gnueabi/libpq.so.5 /usr/lib/arm-linux-gnueabi/libpq.so
+
 ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
 ENV OPENSSL_LIB_DIR="/usr/lib/arm-linux-gnueabi"
 RUN rustup target add arm-unknown-linux-gnueabi
 {%   elif "arm32v7" in target_file %}
+RUN ln -sfnr /usr/lib/arm-linux-gnueabihf/libpq.so.5 /usr/lib/arm-linux-gnueabihf/libpq.so
+
 ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
@@ -168,7 +196,23 @@ RUN rustup target add armv7-unknown-linux-musleabihf
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
+{% if "alpine" in target_file %}
+{%   if "amd64" in target_file %}
+RUN cargo build --features ${DB} --release --target=x86_64-unknown-linux-musl
+{%   elif "arm32v7" in target_file %}
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-musleabihf
+{%   endif %}
+{% elif "alpine" not in target_file %}
+{%   if "amd64" in target_file %}
 RUN cargo build --features ${DB} --release
+{%   elif "arm64v8" in target_file %}
+RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
+{%   elif "arm32v6" in target_file %}
+RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
+{%   elif "arm32v7" in target_file %}
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
+{%   endif %}
+{% endif %}
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -235,10 +279,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
-{%   if "amd64" in target_file %}
-    libmariadbclient-dev \
+    libmariadb-dev-compat \
     libpq5 \
-{%   endif %}
     && rm -rf /var/lib/apt/lists/*
 {% endif %}
 {% if "alpine" in target_file and "arm32v7" in target_file %}

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -20,7 +20,7 @@ FROM bitwardenrs/web-vault@sha256:e40228f94cead5e50af6575fb39850a002dad146dab683
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.46 as build
 
-# AMD64 supports all
+# Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
 
 # Build time options to avoid dpkg warnings and help with reproducible builds.
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
-    libmariadbclient-dev \
+    libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -47,7 +47,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --features ${DB} --release --target=x86_64-unknown-linux-musl
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project

--- a/docker/arm32v6/Dockerfile
+++ b/docker/arm32v6/Dockerfile
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -20,8 +20,8 @@ FROM bitwardenrs/web-vault@sha256:e40228f94cead5e50af6575fb39850a002dad146dab683
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.46 as build
 
-# ARM only supports SQLite for now
-ARG DB=sqlite
+# Debian-based builds support multidb
+ARG DB=sqlite,mysql,postgresql
 
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
@@ -30,6 +30,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
 RUN rustup set profile minimal
 
 # Install required build libs for armel architecture.
+# To compile both mysql and postgresql we need some extra packages for both host arch and target arch
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armel \
@@ -37,7 +38,11 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:armel \
-        libc6-dev:armel
+        libc6-dev:armel \
+        libpq5:armel \
+        libpq-dev \
+        libmariadb-dev:armel \
+        libmariadb-dev-compat:armel
 
 RUN apt-get update \
     && apt-get install -y \
@@ -45,7 +50,8 @@ RUN apt-get update \
         gcc-arm-linux-gnueabi \
     && mkdir -p ~/.cargo \
     && echo '[target.arm-unknown-linux-gnueabi]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabi-gcc"' >> ~/.cargo/config
+    && echo 'linker = "arm-linux-gnueabi-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/arm-linux-gnueabi"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -59,6 +65,24 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+# NOTE: This should be the last apt-get/dpkg for this stage, since after this it will fail because of broken dependencies.
+# For Diesel-RS migrations_macros to compile with MySQL/MariaDB we need to do some magic.
+# We at least need libmariadb3:amd64 installed for the x86_64 version of libmariadb.so (client)
+# We also need the libmariadb-dev-compat:amd64 but it can not be installed together with the :armel version.
+# What we can do is a force install, because nothing important is overlapping each other.
+RUN apt-get install -y libmariadb3:amd64 && \
+    mkdir -pv /tmp/dpkg && \
+    cd /tmp/dpkg && \
+    apt-get download libmariadb-dev-compat:amd64 && \
+    dpkg --force-all -i *.deb && \
+    rm -rf /tmp/dpkg
+
+# For Diesel-RS migrations_macros to compile with PostgreSQL we need to do some magic.
+# The libpq5:armel package seems to not provide a symlink to libpq.so.5 with the name libpq.so.
+# This is only provided by the libpq-dev package which can't be installed for both arch at the same time.
+# Without this specific file the ld command will fail and compilation fails with it.
+RUN ln -sfnr /usr/lib/arm-linux-gnueabi/libpq.so.5 /usr/lib/arm-linux-gnueabi/libpq.so
+
 ENV CC_arm_unknown_linux_gnueabi="/usr/bin/arm-linux-gnueabi-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabi"
@@ -68,7 +92,7 @@ RUN rustup target add arm-unknown-linux-gnueabi
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -100,6 +124,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
+    libmariadb-dev-compat \
+    libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/docker/arm32v7/Dockerfile
+++ b/docker/arm32v7/Dockerfile
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -20,8 +20,8 @@ FROM bitwardenrs/web-vault@sha256:e40228f94cead5e50af6575fb39850a002dad146dab683
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.46 as build
 
-# ARM only supports SQLite for now
-ARG DB=sqlite
+# Debian-based builds support multidb
+ARG DB=sqlite,mysql,postgresql
 
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
@@ -30,6 +30,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
 RUN rustup set profile minimal
 
 # Install required build libs for armhf architecture.
+# To compile both mysql and postgresql we need some extra packages for both host arch and target arch
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture armhf \
@@ -37,7 +38,11 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:armhf \
-        libc6-dev:armhf
+        libc6-dev:armhf \
+        libpq5:armhf \
+        libpq-dev \
+        libmariadb-dev:armhf \
+        libmariadb-dev-compat:armhf
 
 RUN apt-get update \
     && apt-get install -y \
@@ -45,7 +50,8 @@ RUN apt-get update \
         gcc-arm-linux-gnueabihf \
     && mkdir -p ~/.cargo \
     && echo '[target.armv7-unknown-linux-gnueabihf]' >> ~/.cargo/config \
-    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
+    && echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/arm-linux-gnueabihf"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -59,6 +65,24 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+# NOTE: This should be the last apt-get/dpkg for this stage, since after this it will fail because of broken dependencies.
+# For Diesel-RS migrations_macros to compile with MySQL/MariaDB we need to do some magic.
+# We at least need libmariadb3:amd64 installed for the x86_64 version of libmariadb.so (client)
+# We also need the libmariadb-dev-compat:amd64 but it can not be installed together with the :armhf version.
+# What we can do is a force install, because nothing important is overlapping each other.
+RUN apt-get install -y libmariadb3:amd64 && \
+    mkdir -pv /tmp/dpkg && \
+    cd /tmp/dpkg && \
+    apt-get download libmariadb-dev-compat:amd64 && \
+    dpkg --force-all -i *.deb && \
+    rm -rf /tmp/dpkg
+
+# For Diesel-RS migrations_macros to compile with PostgreSQL we need to do some magic.
+# The libpq5:armhf package seems to not provide a symlink to libpq.so.5 with the name libpq.so.
+# This is only provided by the libpq-dev package which can't be installed for both arch at the same time.
+# Without this specific file the ld command will fail and compilation fails with it.
+RUN ln -sfnr /usr/lib/arm-linux-gnueabihf/libpq.so.5 /usr/lib/arm-linux-gnueabihf/libpq.so
+
 ENV CC_armv7_unknown_linux_gnueabihf="/usr/bin/arm-linux-gnueabihf-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/arm-linux-gnueabihf"
@@ -68,7 +92,7 @@ RUN rustup target add armv7-unknown-linux-gnueabihf
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -100,6 +124,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
+    libmariadb-dev-compat \
+    libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/docker/arm32v7/Dockerfile.alpine
+++ b/docker/arm32v7/Dockerfile.alpine
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -47,7 +47,7 @@ RUN rustup target add armv7-unknown-linux-musleabihf
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-musleabihf
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -6,11 +6,11 @@
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
 
-#  This hash is extracted from the docker web-vault builds and it's prefered over a simple tag because it's immutable.
+#  This hash is extracted from the docker web-vault builds and it's preferred over a simple tag because it's immutable.
 #  It can be viewed in multiple ways:
 #  - From the https://hub.docker.com/repository/docker/bitwardenrs/web-vault/tags page, click the tag name and the digest should be there.
 #  - From the console, with the following commands:
-#      docker pull bitwardenrs/web-vault:v2.16.0b
+#      docker pull bitwardenrs/web-vault:v2.16.1
 #      docker image inspect --format "{{.RepoDigests}}" bitwardenrs/web-vault:v2.16.1
 #
 #  - To do the opposite, and get the tag from the hash, you can do:
@@ -20,8 +20,8 @@ FROM bitwardenrs/web-vault@sha256:e40228f94cead5e50af6575fb39850a002dad146dab683
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.46 as build
 
-# ARM only supports SQLite for now
-ARG DB=sqlite
+# Debian-based builds support multidb
+ARG DB=sqlite,mysql,postgresql
 
 # Build time options to avoid dpkg warnings and help with reproducible builds.
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
@@ -30,6 +30,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TZ=UTC TERM=xterm-256color
 RUN rustup set profile minimal
 
 # Install required build libs for arm64 architecture.
+# To compile both mysql and postgresql we need some extra packages for both host arch and target arch
 RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
         /etc/apt/sources.list.d/deb-src.list \
     && dpkg --add-architecture arm64 \
@@ -37,7 +38,11 @@ RUN sed 's/^deb/deb-src/' /etc/apt/sources.list > \
     && apt-get install -y \
         --no-install-recommends \
         libssl-dev:arm64 \
-        libc6-dev:arm64
+        libc6-dev:arm64 \
+        libpq5:arm64 \
+        libpq-dev \
+        libmariadb-dev:arm64 \
+        libmariadb-dev-compat:arm64
 
 RUN apt-get update \
     && apt-get install -y \
@@ -45,7 +50,8 @@ RUN apt-get update \
         gcc-aarch64-linux-gnu \
     && mkdir -p ~/.cargo \
     && echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config \
-    && echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config
+    && echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config \
+    && echo 'rustflags = ["-L/usr/lib/aarch64-linux-gnu"]' >> ~/.cargo/config
 
 ENV CARGO_HOME "/root/.cargo"
 ENV USER "root"
@@ -59,6 +65,24 @@ COPY ./Cargo.* ./
 COPY ./rust-toolchain ./rust-toolchain
 COPY ./build.rs ./build.rs
 
+# NOTE: This should be the last apt-get/dpkg for this stage, since after this it will fail because of broken dependencies.
+# For Diesel-RS migrations_macros to compile with MySQL/MariaDB we need to do some magic.
+# We at least need libmariadb3:amd64 installed for the x86_64 version of libmariadb.so (client)
+# We also need the libmariadb-dev-compat:amd64 but it can not be installed together with the :arm64 version.
+# What we can do is a force install, because nothing important is overlapping each other.
+RUN apt-get install -y libmariadb3:amd64 && \
+    mkdir -pv /tmp/dpkg && \
+    cd /tmp/dpkg && \
+    apt-get download libmariadb-dev-compat:amd64 && \
+    dpkg --force-all -i *.deb && \
+    rm -rf /tmp/dpkg
+
+# For Diesel-RS migrations_macros to compile with PostgreSQL we need to do some magic.
+# The libpq5:arm64 package seems to not provide a symlink to libpq.so.5 with the name libpq.so.
+# This is only provided by the libpq-dev package which can't be installed for both arch at the same time.
+# Without this specific file the ld command will fail and compilation fails with it.
+RUN ln -sfnr /usr/lib/aarch64-linux-gnu/libpq.so.5 /usr/lib/aarch64-linux-gnu/libpq.so
+
 ENV CC_aarch64_unknown_linux_gnu="/usr/bin/aarch64-linux-gnu-gcc"
 ENV CROSS_COMPILE="1"
 ENV OPENSSL_INCLUDE_DIR="/usr/include/aarch64-linux-gnu"
@@ -68,7 +92,7 @@ RUN rustup target add aarch64-unknown-linux-gnu
 # Builds your dependencies and removes the
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
-RUN cargo build --features ${DB} --release
+RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 RUN find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -100,6 +124,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     sqlite3 \
+    libmariadb-dev-compat \
+    libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /data

--- a/hooks/arches.sh
+++ b/hooks/arches.sh
@@ -1,6 +1,6 @@
-# The default Debian-based SQLite images support these arches.
+# The default Debian-based images support these arches for all database connections
 #
-# Other images (Alpine-based, or with other database backends) currently
+# Other images (Alpine-based) currently
 # support only a subset of these.
 arches=(
     amd64
@@ -8,15 +8,6 @@ arches=(
     arm32v7
     arm64v8
 )
-
-case "${DOCKER_REPO}" in
-    *-mysql)
-        arches=(amd64)
-        ;;
-    *-postgresql)
-        arches=(amd64)
-        ;;
-esac
 
 if [[ "${DOCKER_TAG}" == *alpine ]]; then
     # The Alpine build currently only works for amd64.


### PR DESCRIPTION
With some apt/dpkg magic building multidb containers for arm versions
now also works. As long as the build stage and docker-image stage use
the same base (debian buster now) it should all work.

Resolves #530, resolves #1066