### PR TITLE
Set DB Max pool size via environment variables

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -350,6 +350,9 @@ make_config! {
         /// Max database connection retries |> Number of times to retry the database connection during startup, with 1 second between each retry, set to 0 to retry indefinitely
         db_connection_retries:  u32,    false,  def,    15;
 
+        /// Max database pool size |> Number of simultaneous connections to the database
+        db_pool_max_size:       u32,    true,   def,    10;
+        
         /// Bypass admin page security (Know the risks!) |> Disables the Admin Token for the admin page so you may use your own auth in-front
         disable_admin_token:    bool,   true,   def,    false;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,14 +44,14 @@ macro_rules! generate_connections {
             pub fn from_config() -> Result<Self, Error> {
                 let url = CONFIG.database_url();
                 let conn_type = DbConnType::from_url(&url)?;
-
+                let max_size = CONFIG.db_pool_max_size();
                 match conn_type { $(
                     DbConnType::$name => {
                         #[cfg($name)]
                         {
                             paste::paste!{ [< $name _migrations >]::run_migrations()?; }
                             let manager = ConnectionManager::new(&url);
-                            let pool = Pool::builder().build(manager).map_res("Failed to create pool")?;
+                            let pool = Pool::builder().max_size(max_size).build(manager).map_res("Failed to create pool")?;
                             return Ok(Self::$name(pool));
                         }
                         #[cfg(not($name))]


### PR DESCRIPTION
Tiny changes to set DB maximum pool size via environment variable (DB_POOL_MAX_SIZE). Usefull on small test infrastructures with low connection limits to database