### PR TITLE
Fixed issue with building Alpine armv7 image.

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -9,7 +9,7 @@
 {%     set package_arch_name = "" %}
 {%   elif "arm32v7" in target_file %}
 {%     set build_stage_base_image = "messense/rust-musl-cross:armv7-musleabihf" %}
-{%     set runtime_stage_base_image = "cmosh/alpine-arm:3.6" %}
+{%     set runtime_stage_base_image = "balenalib/armv7hf-alpine:3.12" %}
 {%     set package_arch_name = "" %}
 {%   endif %}
 {% elif "amd64" in target_file %}

--- a/docker/arm32v7/Dockerfile.alpine
+++ b/docker/arm32v7/Dockerfile.alpine
@@ -65,7 +65,7 @@ RUN musl-strip target/armv7-unknown-linux-musleabihf/release/bitwarden_rs
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM cmosh/alpine-arm:3.6
+FROM balenalib/armv7hf-alpine:3.12
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80


### PR DESCRIPTION
The runtime image was using a very old Alpine version.
This caused issues with the catatonit install

Now using the Balena armv7hf Alpine image for this.