### PR TITLE
Ensure that a user is actually in an org when applying policies

### DIFF
--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -4,7 +4,7 @@ use crate::api::EmptyResult;
 use crate::db::DbConn;
 use crate::error::MapResult;
 
-use super::Organization;
+use super::{Organization, UserOrgStatus};
 
 db_object! {
     #[derive(Debug, Identifiable, Queryable, Insertable, Associations, AsChangeset)]
@@ -133,6 +133,9 @@ impl OrgPolicy {
                     users_organizations::table.on(
                         users_organizations::org_uuid.eq(org_policies::org_uuid)
                             .and(users_organizations::user_uuid.eq(user_uuid)))
+                )
+                .filter(
+                    users_organizations::status.eq(UserOrgStatus::Confirmed as i32)
                 )
                 .select(org_policies::all_columns)
                 .load::<OrgPolicyDb>(conn)


### PR DESCRIPTION
While this patch (which is based on src/db/models/collection.rs's find_by_user_uuid) was initially to fix #1218, you already pushed https://github.com/dani-garcia/bitwarden_rs/commit/013d4c28b2e06dc654b7f2a1f21b56b1c8a7838d just as I was making the PR.

There's however one case that doesn't seem to account that is fixed by this PR: User B (owner of Org A) can invite User A to Org A, and even if User A doesn't accept this invitation, the policies will be applied to them:

![](https://elixi.re/i/v08c0a43.png)

![](https://elixi.re/i/aghgimx7.png)

I've tested this behavior with and without this patch, verified that that behavior happens, and that this PR resolves that issue.