### PR TITLE
Show last active it on admin users page

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -297,6 +297,11 @@ fn users_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
             usr["cipher_count"] = json!(Cipher::count_owned_by_user(&u.uuid, &conn));
             usr["attachment_count"] = json!(Attachment::count_by_user(&u.uuid, &conn));
             usr["attachment_size"] = json!(get_display_size(Attachment::size_by_user(&u.uuid, &conn) as i32));
+            usr["created_at"] = json!(&u.created_at.format("%Y-%m-%d %H:%M:%S").to_string());
+            usr["last_active"] = match u.last_active(&conn) {
+                Some(timestamp) => json!(timestamp.format("%Y-%m-%d %H:%M:%S").to_string()),
+                None => json!("Never")
+            };
             usr
     }).collect();
 

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -178,4 +178,15 @@ impl Device {
                 .from_db()
         }}
     }
+
+    pub fn find_latest_active_by_user(user_uuid: &str, conn: &DbConn) -> Option<Self> {
+        db_run! { conn: {
+            devices::table
+                .filter(devices::user_uuid.eq(user_uuid))
+                .order(devices::updated_at.desc())
+                .first::<DeviceDb>(conn)
+                .ok()
+                .from_db()
+        }}
+    }
 }

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -288,6 +288,13 @@ impl User {
             users::table.load::<UserDb>(conn).expect("Error loading users").from_db()
         }}
     }
+
+    pub fn last_active(&self, conn: &DbConn) -> Option<NaiveDateTime> {
+        match Device::find_latest_active_by_user(&self.uuid, conn) {
+            Some(device) => Some(device.updated_at),
+            None => None
+        }        
+    }
 }
 
 impl Invitation {

--- a/src/static/templates/admin/users.hbs
+++ b/src/static/templates/admin/users.hbs
@@ -21,6 +21,8 @@
                             <div class="float-left">
                                 <strong>{{Name}}</strong>
                                 <span class="d-block">{{Email}}</span>
+                                <span class="d-block">Created at: {{created_at}}</span>
+                                <span class="d-block">Last active: {{last_active}}</span>
                                 <span class="d-block">
                                     {{#if TwoFactorEnabled}}
                                         <span class="badge badge-success mr-2" title="2FA is enabled">2FA</span>


### PR DESCRIPTION
Feature request from #246.

This change implements saving last login date and time for users to the database and adds this information to the admin panel's user list. I also added the user creation date to the admin page.