### PR TITLE
Updated icon downloading.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -104,7 +104,8 @@
 ## Icon blacklist Regex
 ## Any domains or IPs that match this regex won't be fetched by the icon service.
 ## Useful to hide other servers in the local network. Check the WIKI for more details
-# ICON_BLACKLIST_REGEX=192\.168\.1\.[0-9].*^
+## NOTE: Always enclose this regex withing single quotes!
+# ICON_BLACKLIST_REGEX='^(192\.168\.0\.[0-9]+|192\.168\.1\.[0-9]+)$'
 
 ## Any IP which is not defined as a global IP will be blacklisted.
 ## Useful to secure your internal environment: See https://en.wikipedia.org/wiki/Reserved_IP_addresses for a list of IPs which it will block

--- a/src/config.rs
+++ b/src/config.rs
@@ -527,6 +527,16 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         }
     }
 
+    // Check if the icon blacklist regex is valid
+    if let Some(ref r) = cfg.icon_blacklist_regex {
+        use regex::Regex;
+        let validate_regex = Regex::new(&r);
+        match validate_regex {
+            Ok(_) => (),
+            Err(e) => err!(format!("`ICON_BLACKLIST_REGEX` is invalid: {:#?}", e)),
+        }
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,9 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         .level_for("launch_", log::LevelFilter::Off)
         .level_for("rocket::rocket", log::LevelFilter::Off)
         .level_for("rocket::fairing", log::LevelFilter::Off)
+        // Never show html5ever and hyper::proto logs, too noisy
+        .level_for("html5ever", log::LevelFilter::Off)
+        .level_for("hyper::proto", log::LevelFilter::Off)
         .chain(std::io::stdout());
 
     // Enable smtp debug logging only specifically for smtp when need.


### PR DESCRIPTION
- Added more checks to prevent panics (Removed unwrap)
- Try do download from base domain or add www when the provided domain
  fails
- Added some more domain validation checks to prevent errors
- Added the ICON_BLACKLIST_REGEX to a Lazy Static HashMap which
  speeds-up the checks!
- Validate the Regex before starting/config change.
- Some cleanups
- Disabled some noisy debugging from 2 crates.