### PR TITLE
add opencontainers labels

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -188,6 +188,10 @@ RUN musl-strip target/{{ package_arch_target }}/release/bitwarden_rs
 # because we already have a binary built
 FROM {{ runtime_stage_base_image }}
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -68,6 +68,10 @@ RUN cargo build --features ${DB} --release
 # because we already have a binary built
 FROM debian:buster-slim
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -65,6 +65,10 @@ RUN cargo build --features ${DB} --release --target=x86_64-unknown-linux-musl
 # because we already have a binary built
 FROM alpine:3.12
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/arm32v6/Dockerfile
+++ b/docker/arm32v6/Dockerfile
@@ -109,6 +109,10 @@ RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 # because we already have a binary built
 FROM balenalib/rpi-debian:buster
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/arm32v7/Dockerfile
+++ b/docker/arm32v7/Dockerfile
@@ -109,6 +109,10 @@ RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabih
 # because we already have a binary built
 FROM balenalib/armv7hf-debian:buster
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/arm32v7/Dockerfile.alpine
+++ b/docker/arm32v7/Dockerfile.alpine
@@ -66,6 +66,10 @@ RUN musl-strip target/armv7-unknown-linux-musleabihf/release/bitwarden_rs
 # because we already have a binary built
 FROM balenalib/armv7hf-alpine:3.12
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -109,6 +109,10 @@ RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 # because we already have a binary built
 FROM balenalib/aarch64-debian:buster
 
+LABEL org.opencontainers.image.source="https://github.com/dani-garcia/bitwarden_rs" \
+    org.opencontainers.image.url="https://bitwardenrs.discourse.group" \
+    org.opencontainers.image.licenses="GPL-3.0"
+
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80
 ENV ROCKET_WORKERS=10


### PR DESCRIPTION
There are other useful opencontainer labels though image.source will help renovatebot detect release notes for docker image.

Not sure how you release your docker images.

I have had good experience with using https://github.com/crazy-max/ghaction-docker-meta to add labels when building the docker image.

