### PR TITLE
Improve shutdown behavior (on kubernetes and allow CTRL+C)

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -204,6 +204,7 @@ RUN [ "cross-build-start" ]
 RUN apk add --no-cache \
         openssl \
         curl \
+        dumb-init \
 {%   if "sqlite" in features %}
         sqlite \
 {%   endif %}
@@ -220,13 +221,11 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    dumb-init \
     sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
-{% endif %}
-{% if "alpine" in target_file and "armv7" in target_file %}
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community catatonit
 {% endif %}
 
 RUN mkdir /data
@@ -256,8 +255,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-{% if "alpine" in target_file and "armv7" in target_file %}
-CMD ["catatonit", "/start.sh"]
-{% else %}
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-{% endif %}

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    dumb-init \
     sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
@@ -101,5 +102,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -74,6 +74,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN apk add --no-cache \
         openssl \
         curl \
+        dumb-init \
         sqlite \
         postgresql-libs \
         ca-certificates
@@ -96,5 +97,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -121,6 +121,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    dumb-init \
     sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
@@ -147,5 +148,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -121,6 +121,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    dumb-init \
     sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
@@ -147,5 +148,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -121,6 +121,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
     curl \
+    dumb-init \
     sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
@@ -147,5 +148,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]
-

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -77,9 +77,9 @@ RUN [ "cross-build-start" ]
 RUN apk add --no-cache \
         openssl \
         curl \
+        dumb-init \
         sqlite \
         ca-certificates
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community catatonit
 
 RUN mkdir /data
 
@@ -102,5 +102,5 @@ HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
 WORKDIR /
-CMD ["catatonit", "/start.sh"]
-
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/start.sh"]


### PR DESCRIPTION
**Description of the change**

@mfriedenhagen pointed at an init process in this issue here: https://github.com/dani-garcia/bitwarden_rs/issues/905#issuecomment-753454442
First I thought that this would not help, since Rocket does not explicitly handly any signal sent to it. But it seems that adding an init process like `dumb-init` still improves the shutdown behavior. According to the [documentation](https://github.com/Yelp/dumb-init/blob/master/README.md) of dumb-init this might be the reason why:
> The Linux kernel applies special signal handling to processes which run as PID 1.

**Benefits**

Especially running bitwarden inside kubernetes resulted, that evicting a node which runs bitwarden takes a long time becase we need to wait until kublet kills bitwarden hardly. With this improvement, the container terminates as fast as all other workload.

**Possible drawbacks**

No known drawbacks

**Applicable issues**

- #905
