### PR TITLE
Change `twofactorauth.org` to `2fa.directory`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,7 @@ impl Fairing for AppHeaders {
     }
 
     fn on_response(&self, _req: &Request, res: &mut Response) {
-        res.set_raw_header("Feature-Policy", "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; sync-xhr 'self' https://haveibeenpwned.com https://twofactorauth.org; usb 'none'; vr 'none'");
+        res.set_raw_header("Feature-Policy", "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; sync-xhr 'self' https://haveibeenpwned.com https://2fa.directory; usb 'none'; vr 'none'");
         res.set_raw_header("Referrer-Policy", "same-origin");
         res.set_raw_header("X-Frame-Options", "SAMEORIGIN");
         res.set_raw_header("X-Content-Type-Options", "nosniff");


### PR DESCRIPTION
The `twofactorauth.org` domain has apparently been sold to some company for marketing purposes.

This is related to upstream web vault changes picked up in dani-garcia/bw_web_builds#31.