### PR TITLE
Check for data folder on startup

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -19,7 +19,7 @@ use crate::{
     db::{backup_database, models::*, DbConn, DbConnType},
     error::{Error, MapResult},
     mail,
-    util::{format_naive_datetime_local, get_display_size},
+    util::{format_naive_datetime_local, get_display_size, is_running_in_docker},
     CONFIG,
 };
 
@@ -486,7 +486,7 @@ fn diagnostics(_token: AdminToken, _conn: DbConn) -> ApiResult<Html<String>> {
     let web_vault_version: WebVaultVersion = serde_json::from_str(&vault_version_str)?;
 
     // Execute some environment checks
-    let running_within_docker = std::path::Path::new("/.dockerenv").exists() || std::path::Path::new("/run/.containerenv").exists();
+    let running_within_docker = is_running_in_docker();
     let has_http_access = has_http_access();
     let uses_proxy = env::var_os("HTTP_PROXY").is_some()
         || env::var_os("http_proxy").is_some()

--- a/src/util.rs
+++ b/src/util.rs
@@ -359,6 +359,15 @@ pub fn format_naive_datetime_local(dt: &NaiveDateTime, fmt: &str) -> String {
 }
 
 //
+// Deployment environment methods
+//
+
+/// Returns true if the program is running in Docker or Podman.
+pub fn is_running_in_docker() -> bool {
+    Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists()
+}
+
+//
 // Deserialization methods
 //
 


### PR DESCRIPTION
Currently, when starting up for the first time (running standalone, outside of Docker), bitwarden_rs panics when the `openssl` tool isn't able to create `data/rsa_key.pem` due to the `data` dir not existing:
```
[2021-02-26 18:35:01.596][bitwarden_rs][INFO] JWT keys don't exist, checking if OpenSSL is available...
OpenSSL 1.1.1f  31 Mar 2020
[2021-02-26 18:35:01.604][bitwarden_rs][INFO] OpenSSL detected, creating keys...
genrsa: Can't open "data/rsa_key.pem" for writing, No such file or directory
Can't open data/rsa_key.pem for reading, No such file or directory
140549065942336:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('da
ta/rsa_key.pem','r')
140549065942336:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
unable to load Private Key
Can't open data/rsa_key.der for reading, No such file or directory
140120792266048:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('da
ta/rsa_key.der','rb')
140120792266048:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
unable to load Private Key
[2021-02-26 18:35:01.627][bitwarden_rs][ERROR] Error creating keys, exiting...
```
Instead, we should print a more helpful error message telling the user to create the directory:
> Create the data folder and try again.

Or when running in Docker/Podman:
> Verify that your data volume is mounted at the correct location.
