### PR TITLE
Add a dot in find command.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-OBJECTS := $(shell find -mindepth 2 -name 'Dockerfile*')
+OBJECTS := $(shell find ./ -mindepth 2 -name 'Dockerfile*')
 
 all: $(OBJECTS)
 


### PR DESCRIPTION
Add a dot indicting current directory to search by find. 

find in mac won't work without the dot