### PR TITLE
Client caching

### DIFF
--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -51,10 +51,7 @@ fn icon(domain: String) -> Option<Cached<Content<Vec<u8>>>> {
         return None;
     }
 
-    get_icon(&domain).map(|(icon, cached)| {
-        let cache_ttl = if cached {CONFIG.icon_cache_ttl()} else {CONFIG.icon_cache_negttl()};
-        Cached::ttl(Content(ContentType::new("image", "x-icon"), icon), cache_ttl)
-    })
+    get_icon(&domain).map(|icon| Cached::ttl(Content(ContentType::new("image", "x-icon"), icon), CONFIG.icon_cache_ttl()))
 }
 
 /// Returns if the domain provided is valid or not.
@@ -241,7 +238,7 @@ fn is_domain_blacklisted(domain: &str) -> bool {
     is_blacklisted
 }
 
-fn get_icon(domain: &str) -> Option<(Vec<u8>, bool)> {
+fn get_icon(domain: &str) -> Option<Vec<u8>> {
     let path = format!("{}/{}.png", CONFIG.icon_cache_folder(), domain);
 
     // Check for expiration of negatively cached copy
@@ -250,7 +247,7 @@ fn get_icon(domain: &str) -> Option<(Vec<u8>, bool)> {
     }
 
     if let Some(icon) = get_cached_icon(&path) {
-        return Some((icon, true));
+        return Some(icon);
     }
 
     if CONFIG.disable_icon_download() {
@@ -261,7 +258,7 @@ fn get_icon(domain: &str) -> Option<(Vec<u8>, bool)> {
     match download_icon(&domain) {
         Ok(icon) => {
             save_icon(&path, &icon);
-            Some((icon, false))
+            Some(icon)
         }
         Err(e) => {
             error!("Error downloading icon: {:?}", e);

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,17 +92,21 @@ impl Fairing for CORS {
     }
 }
 
-pub struct Cached<R>(R, &'static str);
+pub struct Cached<R>(R, String);
 
 impl<R> Cached<R> {
-    pub const fn long(r: R) -> Cached<R> {
+    pub fn long(r: R) -> Cached<R> {
         // 7 days
-        Self(r, "public, max-age=604800")
+        Self(r, String::from("public, max-age=604800"))
     }
 
-    pub const fn short(r: R) -> Cached<R> {
+    pub fn short(r: R) -> Cached<R> {
         // 10 minutes
-        Self(r, "public, max-age=600")
+        Self(r, String::from("public, max-age=600"))
+    }
+
+    pub fn ttl(r: R, ttl: u64) -> Cached<R> {
+        Self(r, format!("public, immutable, max-age={}", ttl))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -97,7 +97,7 @@ pub struct Cached<R>(R, String);
 impl<R> Cached<R> {
     pub fn long(r: R) -> Cached<R> {
         // 7 days
-        Self(r, String::from("public, max-age=604800"))
+        Self::ttl(r, 604800)
     }
 
     pub fn short(r: R) -> Cached<R> {


### PR DESCRIPTION
Cache icons on the client too, to reduce requests when loading the homepage.

Caching without `immutable` will still issue requests, and because Rocket doesn't support conditional GETs, it's basically like not caching at all.

This also caches vault static files, which are cachebusted anyway so updates will still work fine. I've not changed the `/` route for this reason.

Bitwarden upstream doesn't do these, but they also use cloudflare for a CDN which makes this far less of an issue. For home users who don't use a global CDN, this should make quite a difference!