### PR TITLE
Just ignore scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Ignore vendored scripts in GitHub stats
-src/static/* linguist-vendored
+src/static/scripts/* linguist-vendored
 


### PR DESCRIPTION
Nothing else in `src/static` is vendored external scripts, so just ignore these.

This also fixes the glob, which previously wasn't matching anything