### PR TITLE
Some admin interface updates.

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -215,9 +215,6 @@ RUN apk add --no-cache \
         openssl \
         curl \
         dumb-init \
-{%   if "sqlite" in features %}
-        sqlite \
-{%   endif %}
 {%   if "mysql" in features %}
         mariadb-connector-c \
 {%   endif %}
@@ -232,7 +229,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dumb-init \
-    sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -86,7 +86,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dumb-init \
-    sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -82,7 +82,6 @@ RUN apk add --no-cache \
         openssl \
         curl \
         dumb-init \
-        sqlite \
         postgresql-libs \
         ca-certificates
 

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -129,7 +129,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dumb-init \
-    sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -129,7 +129,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dumb-init \
-    sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -129,7 +129,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dumb-init \
-    sqlite3 \
     libmariadb-dev-compat \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -86,7 +86,6 @@ RUN apk add --no-cache \
         openssl \
         curl \
         dumb-init \
-        sqlite \
         ca-certificates
 
 RUN mkdir /data

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 use chrono::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use rocket::{
@@ -144,6 +142,7 @@ macro_rules! db_run {
     // Different code for each db
     ( @raw $conn:ident: $( $($db:ident),+ $body:block )+ ) => {
         #[allow(unused)] use diesel::prelude::*;
+        #[allow(unused_variables)]
         match $conn {
             $($(
                 #[cfg($db)]
@@ -221,21 +220,21 @@ macro_rules! db_object {
 // Reexport the models, needs to be after the macros are defined so it can access them
 pub mod models;
 
-/// Creates a back-up of the database using sqlite3
-pub fn backup_database() -> Result<(), Error> {
-    use std::path::Path;
-    let db_url = CONFIG.database_url();
-    let db_path = Path::new(&db_url).parent().unwrap();
-
-    let now: DateTime<Utc> = Utc::now();
-    let file_date = now.format("%Y%m%d").to_string();
-    let backup_command: String = format!("{}{}{}", ".backup 'db_", file_date, ".sqlite3'");
-
-    Command::new("sqlite3")
-        .current_dir(db_path)
-        .args(&["db.sqlite3", &backup_command])
-        .output()
-        .expect("Can't open database, sqlite3 is not available, make sure it's installed and available on the PATH");
+/// Creates a back-up of the sqlite database
+/// MySQL/MariaDB and PostgreSQL are not supported.
+pub fn backup_database(conn: &DbConn) -> Result<(), Error> {
+    db_run! {@raw conn:
+        postgresql, mysql {
+            err!("PostgreSQL and MySQL/MariaDB do not support this backup feature");
+        }
+        sqlite {
+            use std::path::Path;
+            let db_url = CONFIG.database_url();
+            let db_path = Path::new(&db_url).parent().unwrap().to_string_lossy();
+            let file_date = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+            diesel::sql_query(format!("VACUUM INTO '{}/db_{}.sqlite3'", db_path, file_date)).execute(conn)?;
+        }
+    }
 
     Ok(())
 }
@@ -243,29 +242,14 @@ pub fn backup_database() -> Result<(), Error> {
 
 /// Get the SQL Server version
 pub fn get_sql_server_version(conn: &DbConn) -> String {
-    use diesel::sql_types::Text;
-    #[derive(QueryableByName)]
-    struct SqlVersion {
-        #[sql_type = "Text"]
-        version: String,
-    }
-
     db_run! {@raw conn:
         postgresql, mysql {
-            match diesel::sql_query("SELECT version() AS version;").get_result::<SqlVersion>(conn).ok() {
-                Some(v) => {
-                    v.version
-                },
-                _ => "Unknown".to_string()
-            }
+            no_arg_sql_function!(version, diesel::sql_types::Text);
+            diesel::select(version).get_result::<String>(conn).unwrap_or_else(|_| "Unknown".to_string())
         }
         sqlite {
-            match diesel::sql_query("SELECT sqlite_version() AS version;").get_result::<SqlVersion>(conn).ok() {
-                Some(v) => {
-                    v.version
-                },
-                _ => "Unknown".to_string()
-            }
+            no_arg_sql_function!(sqlite_version, diesel::sql_types::Text);
+            diesel::select(sqlite_version).get_result::<String>(conn).unwrap_or_else(|_| "Unknown".to_string())
         }
     }
 }

--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -20,6 +20,7 @@
                     <dd class="col-sm-7">
                         <span id="server-latest">{{diagnostics.latest_release}}<span id="server-latest-commit" class="d-none">-{{diagnostics.latest_commit}}</span></span>
                     </dd>
+                    {{#if diagnostics.web_vault_enabled}}
                     <dt class="col-sm-5">Web Installed
                         <span class="badge badge-success d-none" id="web-success" title="Latest version is installed.">Ok</span>
                         <span class="badge badge-warning d-none" id="web-warning" title="There seems to be an update available.">Update</span>
@@ -33,6 +34,13 @@
                     </dt>
                     <dd class="col-sm-7">
                         <span id="web-latest">{{diagnostics.latest_web_build}}</span>
+                    </dd>
+                    {{/unless}}
+                    {{/if}}
+                    {{#unless diagnostics.web_vault_enabled}}
+                    <dt class="col-sm-5">Web Installed</dt>
+                    <dd class="col-sm-7">
+                        <span id="web-installed">Web Vault is disabled</span>
                     </dd>
                     {{/unless}}
                     <dt class="col-sm-5">Database</dt>
@@ -118,7 +126,10 @@
                     <dd class="col-sm-7">
                         <span id="dns-resolved">{{diagnostics.dns_resolved}}</span>
                     </dd>
-
+                    <dt class="col-sm-5">Date & Time (Local)</dt>
+                    <dd class="col-sm-7">
+                        <span><b>Server:</b> {{diagnostics.server_time_local}}</span>
+                    </dd>
                     <dt class="col-sm-5">Date & Time (UTC)
                         <span class="badge badge-success d-none" id="time-success" title="Time offsets seem to be correct.">Ok</span>
                         <span class="badge badge-danger d-none" id="time-warning" title="Time offsets are too mouch at drift.">Error</span>


### PR DESCRIPTION
- Fixed bug when web-vault is disabled.
- Updated sql-server version check to be simpler thx to @weiznich ( https://github.com/dani-garcia/bitwarden_rs/pull/1548#discussion_r604767196 )
- Use `VACUUM INTO` to create a SQLite backup instead of using the external sqlite3 application.
  - This also removes the dependancy of having the sqlite3 packages installed on the final image unnecessary, and thus removed it.
- Updated backup filename to also have the current time.
- Add specific bitwarden_rs web-vault version check (to match letter patched versions)
  Will work when https://github.com/dani-garcia/bw_web_builds/pull/33 is build (But still works without it also).
